### PR TITLE
Align setup docs with the current addon architecture

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
 # ============================================================================
 # SeriousSportSync configuration. Copy this file to `.env` and fill in.
-# Every value has a sensible default — a minimal setup only needs SESSION_SECRET
-# and (optionally) ADMIN_USER. Indexer sources and debrid keys are configured
-# at runtime (see notes below), not necessarily here.
+# A metadata-only setup needs SESSION_SECRET and (optionally) ADMIN_USER.
+# Playback is optional and uses the companion scraper, direct Newsnab, and/or
+# per-user service credentials configured on the account page.
 # ============================================================================
 
 # ---- Server ----------------------------------------------------------------
@@ -13,8 +13,8 @@ PORT=7000
 # PUBLIC_URL=https://sports.example.com
 
 # ---- Accounts / auth -------------------------------------------------------
-# This addon is multi-user. The root URL is a login page; each user gets their
-# own install URL and configures their own debrid keys in their account page.
+# This addon is multi-user. Each account gets a private install URL and stores
+# its own TorBox, Usenet Ultimate, and Easynews credentials.
 #
 # SESSION_SECRET signs the login cookies. REQUIRED to be >=32 chars in
 # production — the server refuses to boot otherwise (0.22.2). Generate with:
@@ -53,6 +53,13 @@ ADDON_TYPE=movie
 # https://www.thesportsdb.com/free_sports_api
 TSDB_API_KEY=3
 # Seasons to pull. 'auto' derives years from the event window below so we don't
+# Optional metadata sources for custom promotions:
+# - football-data.org competition code + API key
+# - TMDB TV show id + API key for dated sports programmes
+# Keys can also be saved in the admin UI where supported.
+FOOTBALL_DATA_API_KEY=
+TMDB_API_KEY=
+
 # hammer TSDB's rate limit. Or force a comma list, e.g. 2024,2025,2026.
 TSDB_SEASONS=auto
 # Sliding window of events kept in the metadata cache (days back / ahead). The
@@ -64,61 +71,43 @@ EVENT_WINDOW_DAYS_AHEAD=90
 # Metadata refresh cadence in hours (0 disables the scheduler).
 REFRESH_INTERVAL_HOURS=6
 
-# Wikipedia enrichment fetches a poster image for events that lack one from
-# their primary source (UFC + ONE Championship are the only promotions
-# subject to this — others return null from wikipediaTitle and are skipped).
-# Set to "off" if you don't care about per-event posters (defaults / TSDB
-# league art still apply) — significantly speeds up refresh on long windows.
+# Optional artwork enrichment only. When enabled, UFC/ONE events that lack
+# source artwork may receive a poster from their Wikipedia page. Wikipedia is
+# never used for stream discovery. Set "off" for faster metadata refreshes;
+# branded fallback artwork remains available.
 WIKIPEDIA_ENRICH=on
 
-# ---- Indexer sources (bring your own) --------------------------------------
-# The addon needs at least ONE source to resolve streams (metadata works without
-# any). You can set these here, OR — easier — leave them blank and configure
-# them in the web UI at  Admin -> Indexer sources  (those override env and apply
-# without a restart).
+# ---- Optional playback pipelines ------------------------------------------
+# Metadata/catalogs work without any of these.
 #
-# Prowlarr: a search query is fanned out across whatever indexers you've added
-# to your Prowlarr. URL must be reachable from this container.
-PROWLARR_URL=
-PROWLARR_API_KEY=
-# Zilean: self-hosted DMM hashlist index (https://github.com/iPromKnight/zilean).
-# Great for debrid users — hits are likely already cached. Internal service, so
-# point straight at it (not via a VPN proxy), e.g. http://zilean:8181
-ZILEAN_URL=
-
-# 0.33.0 — SeriousSportScraper companion service. The metadata addon
-# delegates content discovery here and resolves the returned hashes
-# through each user's own TorBox key. Optional shared bearer token to
-# stop random callers if the companion is internet-exposed.
+# Pipeline A: companion scraper -> per-user TorBox
+# The bundled _scraper service owns torrent discovery. Configure Prowlarr,
+# Zilean, Knaben, Torznab, TheRARBG, Bitsearch, etc. in the scraper web UI —
+# never in this metadata-addon .env.
 COMPANION_URL=
 COMPANION_AUTH_TOKEN=
-# Override the TorBox API base if you need to (rare).
+# COMPANION_TIMEOUT_MS=20000
 # TORBOX_API_BASE=https://api.torbox.app/v1/api
 
-# Newsnab / NZB indexer (0.30.0 Usenet integration).
-# Any Newznab/Torznab v2 endpoint: NZBgeek, NZBfinder, omgwtfnzbs, drunkenslug.
-# URL = API root, e.g. https://api.nzbgeek.info  (no trailing /api).
-# Categories default to TV-Sport(5080) + TV-Other(5000) + Other(8000); comma-
-# separated. For sport only: NEWSNAB_CATEGORIES=5080
+# Pipeline B: direct Newznab search -> per-user Usenet Ultimate/NzbDAV
+# URLs and keys may be comma-separated and are paired by position.
+# Example: NEWSNAB_URL=https://api.one.example,https://api.two.example
+#          NEWSNAB_API_KEY=key-one,key-two
 NEWSNAB_URL=
 NEWSNAB_API_KEY=
 NEWSNAB_CATEGORIES=5000,5080,8000
 
-# ---- Debrid providers ------------------------------------------------------
-# NOTE: debrid keys are NOT set here. Each user adds their own Real-Debrid /
-# TorBox / Premiumize key in their account page after logging in. This keeps the
-# instance multi-tenant and avoids a shared global key.
-
-# 0.26.0: auto-warm-on-miss is now controlled PURELY by the per-user
-# checkboxes on the account page ("Auto-warm on Real-Debrid / TorBox /
-# Premiumize"). No server-wide env var required. The AUTO_CACHE_ON_MISS
-# env var below is now ignored — left here only so existing deployments
-# don't break if it's set. Safe to remove from your .env.
-# AUTO_CACHE_ON_MISS=off
+# Pipeline C: per-user Easynews
+# No server-wide Easynews setting exists. Users enter credentials on /account.
+#
+# Per-user playback settings are intentionally absent from this file:
+# - TorBox API key
+# - Usenet Ultimate manifest URL
+# - Easynews username/password
 
 # ---- Persistent stream cache + proactive warmer ----------------------------
-# Caches the merged indexer candidate list per event so stream requests skip the
-# live search. A background warmer pre-fills it for recently-aired events.
+# Caches candidate releases and optionally pre-fills recent events. This is
+# active functionality, not the old auto-add-on-miss behavior.
 STREAM_CACHE_TTL_HOURS=6
 STREAM_CACHE_EMPTY_TTL_MINUTES=30
 STREAM_CACHE_REFRESH=on
@@ -126,54 +115,26 @@ STREAM_CACHE_REFRESH_HOURS=3
 STREAM_CACHE_WINDOW_DAYS_BACK=90
 STREAM_CACHE_WINDOW_DAYS_AHEAD=1
 
-# ---- Real-Debrid keyword + 451 denylist (0.22.1) ---------------------------
-# Real-Debrid started keyword-filtering cached torrents in May 2026 (HTTP 451
-# "infringing_file"). Two-layer defence:
-#
-#   (1) RD_BLOCKED_KEYWORDS below — skip the RD row at /stream time for any
-#       candidate whose title matches. Free, no RD calls. The default list
-#       deliberately omits WEB-DL because it's very common in sports rips
-#       (denylist below catches the genuine WEB-DL blocks instead).
-#   (2) Persistent 451 denylist — when RD returns 451 at resolve time, the
-#       hash is recorded to data/rd-denylist.json. Future stream rows skip
-#       RD for that hash for RD_DENYLIST_TTL_DAYS. No user intervention.
-#
-# RD_BLOCKED_KEYWORDS is a comma list, matched against the candidate's title
-# (case-insensitive, word-boundary). If RD widens the filter, add keywords
-# here without redeploying. Common RD-blocked tags: AMZN, NF, CR, YTS, RARBG,
-# WEBRip, WEB-DL.
-# RD_BLOCKED_KEYWORDS=AMZN,NF,CR,YTS,RARBG,WEBRip
-# RD_DENYLIST_TTL_DAYS=30
-#
-# 0.22.3: non-451 RD failures ("not cached / unresolvable" with no DMCA
-# error) are also recorded, with a shorter TTL because the hash may become
-# cached later if another RD user adds it. Default 24h.
-# RD_SOFT_DENYLIST_HOURS=24
-
-# ---- Warmer-time cache verification (0.23.1) -------------------------------
-# The proactive warmer can batch-check every candidate hash against TorBox
-# and Premiumize using their non-destructive cache APIs (no add, no quota
-# cost, no pollution). When a key is set here, advertised TB/PM rows are
-# only shown for candidates the warmer verified as cached — almost
-# eliminates dead clicks for those providers. RD has no equivalent API
-# (instantAvailability was deprecated in 2024), so RD remains optimistic +
-# denylist. Both empty disables verification (falls back to optimistic +
-# denylist for everyone). The cache state on both providers is GLOBAL —
-# one key answers for every user on the instance.
+# Optional admin power-tool keys. These are not user playback credentials.
+# They let the administrator verify candidate cache state and warm selected
+# hashes from the admin interface.
 # WARMER_TB_TOKEN=
 # WARMER_PM_KEY=
 
-# Per-provider failure denylists (0.23.1) — same dual-TTL semantics as
-# RD_DENYLIST_TTL_DAYS / RD_SOFT_DENYLIST_HOURS above. Fallback for hashes
-# the warmer hasn't covered yet (or for which verification got stale).
-# TB_DENYLIST_TTL_DAYS=30
-# TB_SOFT_DENYLIST_HOURS=24
-# PM_DENYLIST_TTL_DAYS=30
-# PM_SOFT_DENYLIST_HOURS=24
+# ---- Stream request tuning -------------------------------------------------
+STREAM_MAX_ROWS=20
+STREAM_PIPELINE_TIMEOUT_MS=8000
+WARM_MAX_ROWS=5
+WARM_RATE_LIMIT_COUNT=5
+WARM_RATE_LIMIT_WINDOW_SEC=3600
+# Set to 1 temporarily when debugging relevance false-negatives.
+# LOG_EXCLUDED_TITLES=0
+# Set to 1 to retain foreign-language releases in candidate filtering.
+# ALLOW_FOREIGN_LANG=0
 
 # ---- Outbound proxy (optional) ---------------------------------------------
-# If you route public indexer traffic through a VPN (e.g. gluetun), set these.
-# Keep internal services (Prowlarr, Zilean) in NO_PROXY so they stay direct.
+# Applies to outbound metadata, Newznab, Easynews, and companion calls from
+# this container. The scraper has its own proxy settings in _scraper/.env.
 # HTTPS_PROXY=http://gluetun:8888
 # HTTP_PROXY=http://gluetun:8888
-# NO_PROXY=localhost,127.0.0.1,gluetun,prowlarr,zilean
+# NO_PROXY=localhost,127.0.0.1,serioussportsync-scraper

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # 📅 SeriousSportSync — Sports Metadata & Calendar Add-on
 
-> A self-hosted Stremio/Nuvio add-on that turns combat sports, pro-wrestling and motorsport into proper meta items — with a built-in calendar of upcoming events.
+> A self-hosted Stremio/Nuvio sports calendar with rich event metadata and optional, user-configured playback through TorBox, Usenet Ultimate, and Easynews.
 >
 > 🎯 **Primarily designed for [Nuvio](https://github.com/zaarrak/Nuvio)** (a Stremio-compatible client). Also works with **Stremio** and other compatible clients.
 
@@ -17,21 +17,27 @@
 
 ## ⚠️ Disclaimer
 
-> This project is a **metadata catalog**, published strictly for **educational** purposes.
+> This project is a **sports metadata catalog and stream orchestrator**, published strictly for **educational** purposes.
 >
-> SeriousSportSync **hosts no content**, ships **no indexers, no credentials, no playback layer**, and has **no affiliation** with any sport, league, broadcaster, or service. The operator brings their own configuration and is solely responsible for ensuring their use complies with applicable laws and any third-party terms of service.
+> SeriousSportSync **hosts no content**, bundles **no service credentials or indexer accounts**, and has **no affiliation** with any sport, league, broadcaster, or service. Playback connectors are optional and use accounts supplied by each user. The operator is solely responsible for ensuring their use complies with applicable laws and third-party terms.
 
 ---
 
 ## ✨ What it does
 
-SeriousSportSync is a **sports metadata add-on and event calendar** for Stremio-compatible clients.
+SeriousSportSync is a **sports metadata add-on, event calendar, and optional stream orchestrator** for Stremio-compatible clients.
 
 - 📅 **Calendar of upcoming events** for every supported sport — see what's airing this week or next month, browsable in Discover.
 - 🏷️ **Proper meta items** for sports events that mainstream meta providers (IMDb / TMDb) don't index — so they actually appear as first-class entries rather than being unfindable.
 - 🔎 **Smart per-event search aliases** built into each promotion (number, year, matchup, session).
+- 🧩 **Custom promotions and match overrides** managed from the admin UI without editing code.
+- 👤 **Per-user playback credentials** for shared deployments.
 
-The add-on only emits metadata and catalog data. Stream playback is the responsibility of the user's separately-configured Stremio environment.
+### Current playback architecture
+
+The add-on can expose streams through a companion scraper with per-user TorBox credentials, direct Newznab search with per-user Usenet Ultimate credentials, and per-user Easynews search.
+
+Prowlarr, Zilean, and similar indexers are configured inside the optional companion scraper (`_scraper`), not in the metadata add-on's root `.env` file. Wikipedia is only an optional artwork fallback for selected promotions; it is never a stream source.
 
 ---
 
@@ -54,7 +60,7 @@ Adding another sport is a single self-contained entry in `lib/promotions.js`.
 ## 🚀 Quick start (Docker)
 
 ```bash
-git clone https://github.com/<your-user>/serioussportsync.git
+git clone https://github.com/Monkfish1337/Serioussportsync.git
 cd serioussportsync
 cp .env.example .env
 # Minimum: SESSION_SECRET (openssl rand -hex 32) and ADMIN_USER.
@@ -79,9 +85,16 @@ Env-driven with sensible defaults. See [`.env.example`](./.env.example) for the 
 | `LOGIN_MAX_FAILS` / `LOGIN_WINDOW_MS` / `LOGIN_LOCKOUT_MS` | `5` / `900000` / `900000` | Per-IP login rate-limit. |
 | `EVENT_WINDOW_START_DATE` | `2025-01-01` | Earliest date included in the catalog window. |
 | `REFRESH_INTERVAL_HOURS` | `6` | How often the metadata cache is refreshed from upstream sources. |
-| `STREAM_MAX_ROWS` | `20` | Cap on rows returned per `/stream` request. |
-| `WIKIPEDIA_ENRICH` | `on` | Backfill per-event posters from Wikipedia when the primary source has none. Set `off` for fastest refresh if you don't need per-event posters. |
-| `STREAM_CACHE_REFRESH` | `off` | Legacy background warmer flag — should stay `off`. |
+| `TSDB_API_KEY` | `3` | TheSportsDB metadata key. |
+| `FOOTBALL_DATA_API_KEY` | — | Optional football-data.org source for custom promotions. |
+| `TMDB_API_KEY` | — | Optional TMDB source for custom promotions. |
+| `COMPANION_URL` | — | Optional companion scraper endpoint for TorBox playback. |
+| `NEWSNAB_URL` / `NEWSNAB_API_KEY` | — | Optional direct Newznab endpoint for Usenet Ultimate playback. |
+| `STREAM_MAX_ROWS` | `20` | Maximum stream rows returned per request. |
+| `WIKIPEDIA_ENRICH` | `on` | Optional poster fallback for selected promotions only. |
+| `STREAM_CACHE_REFRESH` | `on` | Refresh cached stream results in the background. |
+
+Users add their own TorBox, Usenet Ultimate, and Easynews credentials from their account page. Prowlarr/Zilean settings for the bundled scraper belong in `_scraper/.env`, not the root environment.
 
 ---
 

--- a/addon.js
+++ b/addon.js
@@ -158,12 +158,15 @@ function createApp() {
     const events = store.getEvents();
     const meta = store.loadFromDisk() || {};
     res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    const companion = settings.getCompanion();
+    const newsnab = settings.getNewsnab();
     res.send(JSON.stringify({
       ok: true,
       events: events.length,
       updatedAt: meta.updatedAt || null,
-      prowlarrConfigured: !!(config.prowlarr.url && config.prowlarr.apiKey),
-      adminProtected: !!(config.admin.user && config.admin.password),
+      companionConfigured: !!(companion && companion.url),
+      newsnabConfigured: !!(newsnab && newsnab.url && newsnab.apiKey),
+      accountsEnabled: true,
       promotions: promotions.enabled.map((p) => p.id),
       userCount: users.userCount(),
     }));

--- a/config.js
+++ b/config.js
@@ -24,7 +24,7 @@ module.exports = {
   addonId: 'community.serioussportsync',
   addonName: 'SeriousSportSync',
   addonDescription:
-    'Self-hosted sports event metadata for Stremio with built-in multi-debrid stream resolution (Real-Debrid, TorBox, Premiumize). Covers UFC, ONE Championship, WWE, AEW, and Formula 1.',
+    'Self-hosted sports event metadata and calendar for Stremio/Nuvio, with optional TorBox, Usenet Ultimate, and Easynews playback pipelines.',
 
   idPrefix: 'ufc',
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,16 +13,16 @@ services:
       TSDB_API_KEY: "${TSDB_API_KEY:-3}"
       TSDB_SEASONS: "${TSDB_SEASONS:-auto}"
       REFRESH_INTERVAL_HOURS: "${REFRESH_INTERVAL_HOURS:-6}"
-      # Optional debrid stream resolvers (any combination)
-      PROWLARR_URL: "${PROWLARR_URL:-}"
-      PROWLARR_API_KEY: "${PROWLARR_API_KEY:-}"
-      REAL_DEBRID_API_TOKEN: "${REAL_DEBRID_API_TOKEN:-}"
-      TORBOX_API_TOKEN: "${TORBOX_API_TOKEN:-}"
-      PREMIUMIZE_API_KEY: "${PREMIUMIZE_API_KEY:-}"
-      # Optional access control
-      ACCESS_TOKENS: "${ACCESS_TOKENS:-}"
+      # Content discovery. Configure Prowlarr/Zilean/etc in the companion
+      # scraper, not in this metadata-addon container.
+      COMPANION_URL: "${COMPANION_URL:-}"
+      COMPANION_AUTH_TOKEN: "${COMPANION_AUTH_TOKEN:-}"
+      NEWSNAB_URL: "${NEWSNAB_URL:-}"
+      NEWSNAB_API_KEY: "${NEWSNAB_API_KEY:-}"
+      NEWSNAB_CATEGORIES: "${NEWSNAB_CATEGORIES:-5000,5080,8000}"
+      # Accounts
+      SESSION_SECRET: "${SESSION_SECRET}"
       ADMIN_USER: "${ADMIN_USER:-}"
-      ADMIN_PASSWORD: "${ADMIN_PASSWORD:-}"
     volumes:
       - serioussportsync_data:/app/data
     ports:

--- a/lib/http-agent.js
+++ b/lib/http-agent.js
@@ -1,11 +1,8 @@
 // HTTP/HTTPS proxy agent singleton, driven by env vars.
 //
-// If HTTPS_PROXY / HTTP_PROXY is set (typical: http://gluetun:8888), every
-// outbound fetch in the addon (Prowlarr, Zilean, debrid APIs) routes through
-// it — EXCEPT for hosts in NO_PROXY, which go direct. This is important when
-// Prowlarr itself lives behind the proxy host (e.g. PROWLARR_URL points at
-// gluetun:9696 and we don't want to proxy that call through gluetun:8888,
-// which would cause gluetun to refuse with 503).
+// When HTTPS_PROXY / HTTP_PROXY is set, supported outbound metadata and
+// playback requests route through it, except hosts listed in NO_PROXY.
+// This is useful when the addon container runs on a restricted network.
 //
 // NO_PROXY format: comma-separated host names. Matching is case-insensitive
 // and supports leading "." for suffix match (".internal" matches a.internal).

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -12,24 +12,14 @@ function buildManifest(opts) {
   opts = opts || {};
   const userCfg = (opts.user && opts.user.config) || null;
 
-  const envDebrid = !!(config.realDebrid.token || config.torbox.token || config.premiumize.apiKey);
-  const userDebrid = !!(userCfg && (userCfg.rd || userCfg.tb || userCfg.pm));
-  const anyDebrid = envDebrid || userDebrid;
-  // 0.42.4 — Streams are advertised when at least one candidate source is
-  // configured. Post-0.36.0 the primary source is the companion scraper
-  // (delegates to Prowlarr/Zilean/Knaben/TheRARBG/bitsearch/bitmagnet). We
-  // also count a directly-set NEWSNAB_URL (UU/nzbgeek) and per-user Easynews
-  // credentials as valid sources. The legacy Prowlarr/Zilean settings.js
-  // checks are retained for back-compat but nobody sets those anymore.
-  const cs = settings.getCompanion();
-  const pw = settings.getProwlarr();
-  const haveCompanion = !!(cs && cs.url);
-  const haveNewsnab = !!(process.env.NEWSNAB_URL || '').trim();
-  const haveLegacy = !!((pw.url && pw.apiKey) || settings.getZilean().url);
-  const haveEasynews = !!(userCfg && userCfg.easynews && userCfg.easynews.username);
-  const haveSource = haveCompanion || haveNewsnab || haveEasynews || haveLegacy;
-  const streamEnabled = haveSource;
-  void anyDebrid;
+  // Advertise streams only when one of the current playback pipelines is
+  // available: companion scraper, direct Newznab, or per-user Easynews.
+  const companion = settings.getCompanion();
+  const newsnab = settings.getNewsnab();
+  const haveCompanion = !!(companion && companion.url);
+  const haveNewsnab = !!(newsnab.url && newsnab.apiKey);
+  const haveEasynews = !!(userCfg && userCfg.easynewsUsername && userCfg.easynewsPassword);
+  const streamEnabled = haveCompanion || haveNewsnab || haveEasynews;
 
   const idPrefixes = promotions.enabled.map((p) => p.idPrefix + ':');
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name":  "serioussportsync",
     "version": "0.42.14",
-    "description":  "Self-hosted Stremio addon: sports metadata catalog. Delegates content discovery to a separately-deployed companion scraper and resolves results through the user's own TorBox key. Covers UFC, ONE Championship, WWE, AEW, F1, Boxing, MotoGP.",
+    "description":  "Self-hosted Stremio/Nuvio sports metadata calendar with optional per-user TorBox, Usenet Ultimate, and Easynews playback pipelines.",
     "main":  "server.js",
     "scripts":  {
                     "start":  "node server.js",
@@ -18,10 +18,10 @@
                      "mma",
                      "wwe",
                      "aew",
-                     "real-debrid",
                      "torbox",
-                     "premiumize",
-                     "prowlarr",
+                     "usenet",
+                     "newznab",
+                     "easynews",
                      "metadata"
                  ],
     "license":  "MIT",


### PR DESCRIPTION
## Summary

- replace the obsolete root Prowlarr/Zilean and global debrid setup with the current companion, Newznab, and per-user credential model
- explain Wikipedia's limited artwork-enrichment role
- update README, Docker Compose, package metadata, addon description, and health reporting
- advertise streams only when a current playback pipeline is actually configured
- fix the Easynews manifest check to use the current account fields

## Validation

- checked every committed JavaScript file with node --check
- passed module-load and promotion-registry smoke tests (7 enabled promotions)
- passed manifest smoke test for per-user Easynews
- passed git diff --check
- audited public-facing files for obsolete root configuration names