### PR TITLE
Test and document Docker Compose deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,9 +98,32 @@ jobs:
           "
 
   docker:
-    name: Docker build
+    name: Docker Compose smoke test
     runs-on: ubuntu-latest
+    env:
+      SESSION_SECRET: ci-only-do-not-use-in-prod-0000000000000000000000000000000000
+      ADMIN_USER: ci-admin
     steps:
       - uses: actions/checkout@v4
-      - name: Build image (no push)
-        run: docker build -t serioussportsync:ci .
+
+      - name: Prepare test environment
+        run: cp .env.example .env
+
+      - name: Validate Compose configuration
+        run: docker compose config --quiet
+
+      - name: Build and start through Compose
+        run: docker compose up -d --build --wait --wait-timeout 120
+
+      - name: Verify health endpoint
+        run: |
+          curl --fail --show-error --retry 5 --retry-delay 2 \
+            http://127.0.0.1:7000/health
+
+      - name: Show container logs on failure
+        if: failure()
+        run: docker compose logs --no-color
+
+      - name: Stop test stack
+        if: always()
+        run: docker compose down --volumes --remove-orphans

--- a/README.md
+++ b/README.md
@@ -72,6 +72,20 @@ The container listens on `:7000`.
 1. 🔑 Open `http://<your-server>:7000/` — login / first-run signup page. Create an account; if its username matches `ADMIN_USER`, it's auto-promoted to admin.
 2. ✅ Copy your install URL from the account page and add it to your Stremio-compatible client (Add-ons → paste URL → Install).
 
+### Updating a Docker deployment
+
+Once the repository is cloned on the server, future updates do not require
+copying application files:
+
+```bash
+git pull
+docker compose up -d --build --remove-orphans
+```
+
+Compose rebuilds and replaces the application container while keeping accounts,
+event data, and settings in the `serioussportsync_data` volume. Check the
+rollout with `docker compose ps` and `docker compose logs -f serioussportsync`.
+
 ---
 
 ## ⚙️ Configuration


### PR DESCRIPTION
## Summary

- replace the Dockerfile-only CI check with a complete Docker Compose smoke test
- validate the Compose configuration before startup
- build and start the service through Compose, wait for container health, and verify the /health endpoint
- capture Compose logs on failure and always remove the test stack
- document pull-and-rebuild server updates so application files no longer need manual transfer

## Why

The repository already contained a Compose definition, but CI only built the Dockerfile and never proved the Compose deployment path could start successfully.

## Validation

- git diff --check
- exact Compose route will run in GitHub Actions on this pull request
- local Docker execution was unavailable because Docker is not installed on the current Windows machine