### PR TITLE
Publish a standard Compose-ready container image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,10 +110,10 @@ jobs:
         run: cp .env.example .env
 
       - name: Validate Compose configuration
-        run: docker compose config --quiet
+        run: docker compose -f docker-compose.yml -f docker-compose.dev.yml config --quiet
 
       - name: Build and start through Compose
-        run: docker compose up -d --build --wait --wait-timeout 120
+        run: docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build --wait --wait-timeout 120
 
       - name: Verify health endpoint
         run: |
@@ -122,8 +122,8 @@ jobs:
 
       - name: Show container logs on failure
         if: failure()
-        run: docker compose logs --no-color
+        run: docker compose -f docker-compose.yml -f docker-compose.dev.yml logs --no-color
 
       - name: Stop test stack
         if: always()
-        run: docker compose down --volumes --remove-orphans
+        run: docker compose -f docker-compose.yml -f docker-compose.dev.yml down --volumes --remove-orphans

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,72 @@
+name: Publish container
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: monkfish1337/serioussportsync
+
+jobs:
+  publish-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Sign in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image tags and labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=tag
+            type=sha
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+
+      - name: Build and publish image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify public image through Compose
+        if: github.ref == 'refs/heads/main'
+        env:
+          SESSION_SECRET: ci-only-do-not-use-in-prod-0000000000000000000000000000000000
+          ADMIN_USER: ci-admin
+        run: |
+          cp .env.example .env
+          docker logout ghcr.io
+          docker compose pull
+          docker compose up -d --wait --wait-timeout 120
+          curl --fail --show-error --retry 5 --retry-delay 2 http://127.0.0.1:7000/health
+
+      - name: Show container logs on failure
+        if: failure() && github.ref == 'refs/heads/main'
+        run: docker compose logs --no-color
+
+      - name: Stop test stack
+        if: always() && github.ref == 'refs/heads/main'
+        run: docker compose down --volumes --remove-orphans

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ git clone https://github.com/Monkfish1337/Serioussportsync.git
 cd serioussportsync
 cp .env.example .env
 # Minimum: SESSION_SECRET (openssl rand -hex 32) and ADMIN_USER.
-docker compose up -d --build
+docker compose pull
+docker compose up -d
 ```
 
 The container listens on `:7000`.
@@ -79,12 +80,22 @@ copying application files:
 
 ```bash
 git pull
-docker compose up -d --build --remove-orphans
+docker compose pull
+docker compose up -d --remove-orphans
 ```
 
-Compose rebuilds and replaces the application container while keeping accounts,
+Compose pulls and replaces the application container while keeping accounts,
 event data, and settings in the `serioussportsync_data` volume. Check the
 rollout with `docker compose ps` and `docker compose logs -f serioussportsync`.
+
+### Local source builds
+
+Developers can build the checked-out source by layering the development
+override over the normal deployment file:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
+```
 
 ---
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,3 @@
+services:
+  serioussportsync:
+    build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   serioussportsync:
     container_name: serioussportsync
-    build: .
+    image: ghcr.io/monkfish1337/serioussportsync:latest
     restart: unless-stopped
     env_file:
       - .env


### PR DESCRIPTION
## Summary

- make the root docker-compose.yml a standard pull-based deployment using ghcr.io/monkfish1337/serioussportsync:latest
- add docker-compose.dev.yml as the explicit local source-build override
- publish latest, version-tag, and commit-SHA images from GitHub Actions
- link the image to this repository with its OCI source label
- log out of GHCR after publishing and smoke-test the public image through the root Compose file
- update quick-start and update commands to use docker compose pull

## Impact

Container users can deploy and update with normal Compose pull/up commands. Developers retain a source-build path by layering the development override.

## Validation

- git diff --check
- existing PR CI will build and run the source through the two-file Compose development configuration
- after merge, the container workflow will publish the image and test an unauthenticated pull plus /health