### PR TITLE
Restore direct Prowlarr in the admin panel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,13 +80,19 @@ WIKIPEDIA_ENRICH=on
 # ---- Optional playback pipelines ------------------------------------------
 # Metadata/catalogs work without any of these.
 #
-# Pipeline A: companion scraper -> per-user TorBox
-# The bundled _scraper service owns torrent discovery. Configure Prowlarr,
-# Zilean, Knaben, Torznab, TheRARBG, Bitsearch, etc. in the scraper web UI —
-# never in this metadata-addon .env.
+# Pipeline A: torrent discovery -> per-user TorBox
+#
+# Recommended: the bundled _scraper service can combine Prowlarr, Zilean,
+# Knaben, Torznab, TheRARBG, Bitsearch, and other sources.
 COMPANION_URL=
 COMPANION_AUTH_TOKEN=
 # COMPANION_TIMEOUT_MS=20000
+#
+# Optional direct Prowlarr alternative/supplement. These can also be saved in
+# Admin -> Torrent discovery and metadata sources, which overrides env values.
+PROWLARR_URL=
+PROWLARR_API_KEY=
+#
 # TORBOX_API_BASE=https://api.torbox.app/v1/api
 
 # Pipeline B: direct Newznab search -> per-user Usenet Ultimate/NzbDAV

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.42.15
+
+### Direct Prowlarr
+
+- Restored optional direct Prowlarr configuration in the SeriousSportSync
+  admin panel and through `PROWLARR_URL` / `PROWLARR_API_KEY`.
+- Direct Prowlarr and companion-scraper candidates now merge by info hash
+  before relevance filtering and per-user TorBox cache checks.
+- Restored Prowlarr hash extraction and bounded download-proxy hydration
+  without returning raw torrent rows to clients.
+- Added Prowlarr status to `/health` and stream availability detection to
+  the addon manifest.
+
 ## 0.42.14
 
 Catch-up release covering the unpublished work since GitHub version 0.33.0.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 >
 > 🎯 **Primarily designed for [Nuvio](https://github.com/zaarrak/Nuvio)** (a Stremio-compatible client). Also works with **Stremio** and other compatible clients.
 
-[![Version](https://img.shields.io/badge/version-0.42.14-blue.svg)](#)
+[![Version](https://img.shields.io/badge/version-0.42.15-blue.svg)](#)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 [![Nuvio](https://img.shields.io/badge/Nuvio-compatible-orange.svg)](#)
 [![Stremio Add-on](https://img.shields.io/badge/Stremio-compatible-7b5bf5.svg)](https://www.stremio.com/)
@@ -72,9 +72,9 @@ SeriousSportSync is a **sports metadata add-on, event calendar, and optional str
 
 ### Current playback architecture
 
-The add-on can expose streams through a companion scraper with per-user TorBox credentials, direct Newznab search with per-user Usenet Ultimate credentials, and per-user Easynews search.
+The add-on can expose streams through the companion scraper and/or direct Prowlarr with per-user TorBox credentials, direct Newznab search with per-user Usenet Ultimate credentials, and per-user Easynews search.
 
-Prowlarr, Zilean, and similar indexers are configured inside the optional companion scraper (`_scraper`), not in the metadata add-on's root `.env` file. Wikipedia is only an optional artwork fallback for selected promotions; it is never a stream source.
+Prowlarr can be configured directly in the SeriousSportSync admin panel or inside the optional companion scraper (`_scraper`). The companion remains useful when combining Prowlarr with Zilean and other discovery sources. Wikipedia is only an optional artwork fallback for selected promotions; it is never a stream source.
 
 ---
 
@@ -140,12 +140,13 @@ Env-driven with sensible defaults. See [`.env.example`](./.env.example) for the 
 | `FOOTBALL_DATA_API_KEY` | — | Optional football-data.org source for custom promotions. |
 | `TMDB_API_KEY` | — | Optional TMDB source for custom promotions. |
 | `COMPANION_URL` | — | Optional companion scraper endpoint for TorBox playback. |
+| `PROWLARR_URL` / `PROWLARR_API_KEY` | — | Optional direct Prowlarr source; can instead be saved in the admin panel. |
 | `NEWSNAB_URL` / `NEWSNAB_API_KEY` | — | Optional direct Newznab endpoint for Usenet Ultimate playback. |
 | `STREAM_MAX_ROWS` | `20` | Maximum stream rows returned per request. |
 | `WIKIPEDIA_ENRICH` | `on` | Optional poster fallback for selected promotions only. |
 | `STREAM_CACHE_REFRESH` | `on` | Refresh cached stream results in the background. |
 
-Users add their own TorBox, Usenet Ultimate, and Easynews credentials from their account page. Prowlarr/Zilean settings for the bundled scraper belong in `_scraper/.env`, not the root environment.
+Users add their own TorBox, Usenet Ultimate, and Easynews credentials from their account page. Companion-managed Prowlarr/Zilean settings belong in `_scraper/.env`; a direct Prowlarr connection belongs in the SeriousSportSync admin panel or root environment.
 
 ---
 

--- a/addon.js
+++ b/addon.js
@@ -159,12 +159,14 @@ function createApp() {
     const meta = store.loadFromDisk() || {};
     res.setHeader('Content-Type', 'application/json; charset=utf-8');
     const companion = settings.getCompanion();
+    const prowlarr = settings.getProwlarr();
     const newsnab = settings.getNewsnab();
     res.send(JSON.stringify({
       ok: true,
       events: events.length,
       updatedAt: meta.updatedAt || null,
       companionConfigured: !!(companion && companion.url),
+      prowlarrConfigured: !!(prowlarr && prowlarr.url && prowlarr.apiKey),
       newsnabConfigured: !!(newsnab && newsnab.url && newsnab.apiKey),
       accountsEnabled: true,
       promotions: promotions.enabled.map((p) => p.id),
@@ -792,19 +794,17 @@ function createApp() {
     });
   });
 
-  // Save the companion-scraper endpoint.
-  //
-  // 0.36.0: stopped writing the legacy Prowlarr/Zilean fields from this
-  // form (they were already labelled "Unused by 0.33.0+" in the UI).
-  // Existing values in settings.json stay intact — we just no longer
-  // touch them on save. The metadata addon doesn't query Prowlarr/Zilean
-  // directly any more; the companion scraper owns indexer discovery.
+  // Save server-wide metadata and torrent discovery sources.
   app.post('/admin/sources', requireAdmin, (req, res) => {
     const b = req.body || {};
     try {
       settings.setCompanion({
         url: String(b.companionUrl || ''),
         authToken: String(b.companionAuthToken || ''),
+      });
+      settings.setProwlarr({
+        url: String(b.prowlarrUrl || ''),
+        apiKey: String(b.prowlarrApiKey || ''),
       });
       // 0.38.1: football-data.org API key — admin-saved value wins over the
       // FOOTBALL_DATA_API_KEY env var. Empty input is allowed (falls back to env).
@@ -1130,8 +1130,9 @@ function renderAdminPage(currentUser, opts) {
   try { scStats = streamcache.stats(); } catch (e) { /* file may not exist yet */ }
   const scUpdated = scStats.updatedAt ? scStats.updatedAt.slice(0, 16).replace('T', ' ') : 'never';
 
-  // 0.33.0: companion-scraper URL is the primary content config.
+  // Torrent discovery endpoints are optional and may be used together.
   const _comp = settings.getCompanion();
+  const _prowlarr = settings.getProwlarr();
   // 0.38.1: football-data.org API key field on /admin Sources so admins can
   // save/rotate the key without editing docker-compose.yml.
   const _fd = settings.getFootballData();
@@ -1149,15 +1150,24 @@ function renderAdminPage(currentUser, opts) {
 
     // Companion scraper config
     + '<div class="card mb-3">'
-    +   '<div class="card-header"><h3 class="card-title">Companion scraper</h3></div>'
+    +   '<div class="card-header"><h3 class="card-title">Torrent discovery and metadata sources</h3></div>'
     +   '<div class="card-body">'
-    +     '<p class="text-secondary small mb-3">URL of the SeriousSportScraper companion service you have deployed. The metadata addon delegates content discovery to it and resolves the returned hashes through each user\'s own TorBox key. Leave blank to disable the TorBox pipeline.</p>'
+    +     '<p class="text-secondary small mb-3">URL of the SeriousSportScraper companion service you have deployed. The metadata addon delegates content discovery to it and resolves the returned hashes through each user\'s own TorBox key. Leave blank if you only want to use direct Prowlarr.</p>'
     +     '<form method="POST" action="/admin/sources">'
     +       '<div class="mb-3">'
     +         '<label class="form-label">Companion URL</label>'
     +         '<input class="form-control text-mono" name="companionUrl" value="' + escapeHtml(_comp.url) + '" placeholder="http://scraper:8080" autocomplete="off">'
     +       '</div>'
     +       secretField('Companion auth token (optional)', 'companionAuthToken', _comp.authToken, 'shared bearer if scraper is internet-exposed')
+
+    +       '<hr class="my-4">'
+    +       '<h4 class="mb-2">Direct Prowlarr (optional)</h4>'
+    +       '<p class="text-secondary small mb-3">Query Prowlarr directly from SeriousSportSync as an alternative or supplement to the companion scraper. Results are filtered and checked against each user\'s TorBox account; raw torrent rows are never returned. The URL must be reachable from this container. For a separate Dockge stack, use a shared Docker network or the server address; <code>localhost</code> refers to this container.</p>'
+    +       '<div class="mb-3">'
+    +         '<label class="form-label">Prowlarr URL</label>'
+    +         '<input class="form-control text-mono" type="url" name="prowlarrUrl" value="' + escapeHtml(_prowlarr.url) + '" placeholder="http://prowlarr:9696" autocomplete="off">'
+    +       '</div>'
+    +       secretField('Prowlarr API key', 'prowlarrApiKey', _prowlarr.apiKey, 'Settings → General → Security')
 
     // 0.38.1: football-data.org API key block. Saved value overrides
     // FOOTBALL_DATA_API_KEY env var. Used by custom promotions whose source
@@ -1172,7 +1182,7 @@ function renderAdminPage(currentUser, opts) {
     // (qBit + SAB) at /downloaders. SSS only proxies — see /admin/search.
     +       '<hr class="my-4">'
     +       '<h4 class="mb-2">General search</h4>'
-    +       '<p class="text-secondary small mb-0">The <a href="/admin/search" class="link-primary">/admin/search</a> page proxies through to the companion scraper above. Configure Prowlarr instances on the scraper\'s <a href="' + escapeHtml(_comp.url || '#') + '/sources" target="_blank" rel="noopener" class="link-primary">Sources</a> page and qBit / SAB credentials on its <a href="' + escapeHtml(_comp.url || '#') + '/downloaders" target="_blank" rel="noopener" class="link-primary">Downloaders</a> page (scraper v0.1.4+).</p>'
+    +       '<p class="text-secondary small mb-0">The <a href="/admin/search" class="link-primary">/admin/search</a> page proxies through to the companion scraper above. The direct Prowlarr option above is also available in the event power tool. Configure companion-managed Prowlarr instances on the scraper\'s <a href="' + escapeHtml(_comp.url || '#') + '/sources" target="_blank" rel="noopener" class="link-primary">Sources</a> page and qBit / SAB credentials on its <a href="' + escapeHtml(_comp.url || '#') + '/downloaders" target="_blank" rel="noopener" class="link-primary">Downloaders</a> page (scraper v0.1.4+).</p>'
 
     +       '<hr class="my-4">'
     +       '<button class="btn btn-primary" type="submit">Save sources</button>'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,8 @@ services:
       TSDB_API_KEY: "${TSDB_API_KEY:-3}"
       TSDB_SEASONS: "${TSDB_SEASONS:-auto}"
       REFRESH_INTERVAL_HOURS: "${REFRESH_INTERVAL_HOURS:-6}"
-      # Content discovery. Configure Prowlarr/Zilean/etc in the companion
-      # scraper, not in this metadata-addon container.
+      # Content discovery. The companion can combine Prowlarr/Zilean/etc;
+      # a direct Prowlarr connection can also be saved in the admin panel.
       COMPANION_URL: "${COMPANION_URL:-}"
       COMPANION_AUTH_TOKEN: "${COMPANION_AUTH_TOKEN:-}"
       NEWSNAB_URL: "${NEWSNAB_URL:-}"

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -13,13 +13,15 @@ function buildManifest(opts) {
   const userCfg = (opts.user && opts.user.config) || null;
 
   // Advertise streams only when one of the current playback pipelines is
-  // available: companion scraper, direct Newznab, or per-user Easynews.
+  // available: companion scraper, direct Prowlarr, direct Newznab, or per-user Easynews.
   const companion = settings.getCompanion();
+  const prowlarr = settings.getProwlarr();
   const newsnab = settings.getNewsnab();
   const haveCompanion = !!(companion && companion.url);
+  const haveProwlarr = !!(prowlarr.url && prowlarr.apiKey);
   const haveNewsnab = !!(newsnab.url && newsnab.apiKey);
   const haveEasynews = !!(userCfg && userCfg.easynewsUsername && userCfg.easynewsPassword);
-  const streamEnabled = haveCompanion || haveNewsnab || haveEasynews;
+  const streamEnabled = haveCompanion || haveProwlarr || haveNewsnab || haveEasynews;
 
   const idPrefixes = promotions.enabled.map((p) => p.idPrefix + ':');
 

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -76,6 +76,14 @@ function getNewsnab() {
   };
 }
 
+function setProwlarr({ url, apiKey }) {
+  const st = loadAll();
+  st.prowlarr = { url: str(url), apiKey: str(apiKey) };
+  st.updatedAt = new Date().toISOString();
+  saveAll(st);
+  return st;
+}
+
 function setSources({ prowlarrUrl, prowlarrApiKey, zileanUrl, newsnabUrl, newsnabApiKey, newsnabCategories }) {
   const st = loadAll();
   st.prowlarr = { url: str(prowlarrUrl), apiKey: str(prowlarrApiKey) };
@@ -131,7 +139,7 @@ function setFootballData({ apiKey }) {
 }
 
 module.exports = {
-  getProwlarr, getZilean, getNewsnab, setSources,
+  getProwlarr, setProwlarr, getZilean, getNewsnab, setSources,
   getCompanion, setCompanion,
   getFootballData, setFootballData,
 };

--- a/lib/sources/prowlarr.js
+++ b/lib/sources/prowlarr.js
@@ -1,11 +1,187 @@
-// 0.33.0: Prowlarr integration retired from the metadata addon.
-//
-// Indexer-side work moved to the SeriousSportScraper companion service,
-// which the operator deploys separately and configures via the admin
-// "Companion Scraper URL" field. This keeps the public metadata addon
-// free of any content-providing code paths.
-//
-// Stub retained so any leftover require('./sources/prowlarr') in older
-// versions of the user's data files or downstream forks doesn't crash.
+// Direct Prowlarr search client (optional alternative to the companion scraper).
+// Uses the unified /api/v1/search endpoint, which fans out across every
+// indexer Prowlarr has configured. Many results return infoHash=null and
+// the hash is only reachable by following Prowlarr's /download proxy
+// redirect, which typically 301s to a magnet: URL. We hydrate those in
+// a bounded-concurrency second pass.
 
-module.exports = { search: async () => [], multiSearch: async () => [] };
+const fetch = require('node-fetch');
+const settings = require('../settings');
+const httpAgent = require('../http-agent');
+
+function delay(ms) { return new Promise((r) => setTimeout(r, ms)); }
+
+async function search(query, options) {
+  const opts = options || {};
+  const log = opts.log || (() => {});
+  const pw = settings.getProwlarr();
+  if (!pw.url || !pw.apiKey) { log('  prowlarr: URL/API key not configured'); return []; }
+
+  const params = new URLSearchParams({
+    query, type: 'search', limit: String(opts.limit || 100),
+  });
+  for (const cat of ['2000', '5000', '8000']) params.append('categories', cat);
+
+  const url = pw.url.replace(/\/$/, '') + '/api/v1/search?' + params.toString();
+
+  let res;
+  try {
+    res = await fetch(url, httpAgent.fetchOpts({
+      headers: { 'X-Api-Key': pw.apiKey, Accept: 'application/json' },
+      timeout: 15000,
+    }, url));
+  } catch (err) { log('  prowlarr: network error: ' + err.message); return []; }
+  if (!res.ok) { log('  prowlarr: HTTP ' + res.status + ' ' + res.statusText); return []; }
+  let body;
+  try { body = await res.json(); } catch (err) { log('  prowlarr: bad JSON: ' + err.message); return []; }
+  if (!Array.isArray(body)) return [];
+  return body;
+}
+
+// Base32 (RFC 4648) -> bytes. Some trackers encode the 20-byte btih as
+// 32 chars of base32 instead of 40 hex chars.
+function base32ToBytes(s) {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+  s = s.toUpperCase().replace(/=+$/, '');
+  const out = [];
+  let buf = 0, bits = 0;
+  for (const ch of s) {
+    const v = alphabet.indexOf(ch);
+    if (v < 0) return null;
+    buf = (buf << 5) | v; bits += 5;
+    if (bits >= 8) { bits -= 8; out.push((buf >> bits) & 0xff); }
+  }
+  return out;
+}
+
+// Recover infoHash from any synchronously-available field.
+function extractInfoHash(result) {
+  if (result.infoHash && /^[a-f0-9]{40}$/i.test(result.infoHash)) {
+    return result.infoHash.toLowerCase();
+  }
+  const candidates = [result.magnetUrl, result.downloadUrl, result.guid, result.infoUrl];
+  for (const c of candidates) {
+    if (!c || typeof c !== 'string') continue;
+    const m = c.match(/urn:btih:([A-Fa-f0-9]{40}|[A-Z2-7]{32})/i);
+    if (m) {
+      const h = m[1];
+      if (/^[a-f0-9]{40}$/i.test(h)) return h.toLowerCase();
+      try {
+        const bin = base32ToBytes(h);
+        if (bin && bin.length === 20) {
+          return Array.from(bin).map(function (b) { return b.toString(16).padStart(2, '0'); }).join('');
+        }
+      } catch (_) { /* fall through */ }
+    }
+    const m2 = c.match(/\b([A-Fa-f0-9]{40})\b/);
+    if (m2) return m2[1].toLowerCase();
+  }
+  return '';
+}
+
+// Async hydration: for results without a syncable hash, GET the downloadUrl
+// with redirect=manual and pull the hash from the magnet: Location header.
+async function hydrateHashViaDownloadProxy(result, log) {
+  if (!result.downloadUrl || typeof result.downloadUrl !== 'string') return null;
+  let res;
+  try {
+    res = await fetch(result.downloadUrl, httpAgent.fetchOpts({
+      redirect: 'manual', timeout: 5000, method: 'GET',
+    }, result.downloadUrl));
+  } catch (err) {
+    if (log) log('    hydrate fail (' + (result.indexer || '?') + '): ' + err.message);
+    // Signal a transport failure so the caller can skip this indexer's other
+    // results for the rest of the batch (e.g. a dead/CF-blocked tracker whose
+    // download proxy always times out via the VPN exit).
+    return { error: true };
+  }
+  const loc = res.headers.get('location') || '';
+  if (loc.startsWith('magnet:')) {
+    const m = loc.match(/urn:btih:([A-Fa-f0-9]{40})/i);
+    if (m) return { hash: m[1].toLowerCase(), magnetUrl: loc };
+  }
+  // 200 with .torrent body would need bencode + sha1 of info dict — not
+  // implemented; we skip these. Most CF-free indexers redirect to magnet.
+  return null;
+}
+
+async function hydrateAll(results, log, concurrency) {
+  // Only hydrate results that (a) lack a sync-extractable hash, (b) have
+  // a downloadUrl we can fetch, and (c) have at least one seeder (dead
+  // torrents aren't worth the round-trip). Cap to top HYDRATE_MAX by
+  // seeders. The cap is generous because a result whose indexer has already
+  // failed once this batch is skipped instantly (see failedIndexers below),
+  // so one dead indexer (e.g. a CF-blocked tracker whose download
+  // proxy always times out) can't crowd out hydratable results from others.
+  const HYDRATE_MAX = 25;
+  const needs = results
+    .filter((r) => !r._hash && r.downloadUrl && (r.seeders || 0) > 0)
+    .sort((a, b) => (b.seeders || 0) - (a.seeders || 0))
+    .slice(0, HYDRATE_MAX);
+  if (needs.length === 0) return 0;
+  if (log) log('  prowlarr: hydrating up to ' + needs.length + ' by seeders');
+  const failedIndexers = new Set();
+  let i = 0, hydrated = 0, skipped = 0;
+  async function worker() {
+    while (true) {
+      const idx = i++;
+      if (idx >= needs.length) return;
+      const r = needs[idx];
+      // Skip indexers already shown to be dead this batch — instant, frees the
+      // worker to try a result from a working indexer instead.
+      if (r.indexer && failedIndexers.has(r.indexer)) { skipped++; continue; }
+      const got = await hydrateHashViaDownloadProxy(r, log);
+      if (got && got.hash) { r._hash = got.hash; r._magnet = got.magnetUrl; hydrated++; }
+      else if (got && got.error && r.indexer) failedIndexers.add(r.indexer);
+    }
+  }
+  const N = Math.max(1, Math.min(concurrency || 2, needs.length));
+  await Promise.all(Array.from({ length: N }, worker));
+  if (log && (skipped > 0 || failedIndexers.size > 0)) {
+    log('  prowlarr: skipped ' + skipped + ' result(s) from dead indexer(s): '
+      + (Array.from(failedIndexers).join(', ') || 'none'));
+  }
+  return hydrated;
+}
+
+async function multiSearch(queries, options) {
+  const opts = options || {};
+  const log = opts.log || (() => {});
+  const seen = new Set();
+  const out = [];
+  const collected = [];
+
+  for (const q of queries) {
+    log('  prowlarr: query "' + q + '"');
+    const results = await search(q, { log });
+    log('    -> ' + results.length + ' raw results');
+    for (const r of results) {
+      r._hash = extractInfoHash(r);
+      collected.push(r);
+    }
+    if (queries.length > 1) await delay(150);
+  }
+
+  const hydrated = await hydrateAll(collected, log, 4);
+  let dropped = 0;
+  for (const r of collected) {
+    const hash = r._hash;
+    if (!hash) { dropped++; continue; }
+    if (seen.has(hash)) continue;
+    seen.add(hash);
+    out.push({
+      title: r.title || '',
+      infoHash: hash,
+      size: r.size || 0,
+      seeders: r.seeders || 0,
+      leechers: r.leechers || 0,
+      magnetUrl: r.magnetUrl || r._magnet || null,
+      indexer: r.indexer || null,
+      publishDate: r.publishDate || null,
+    });
+  }
+  if (hydrated > 0) log('  prowlarr: hydrated ' + hydrated + ' result(s) via download proxy');
+  if (dropped > 0) log('  prowlarr: dropped ' + dropped + ' result(s) with no recoverable hash');
+  return out;
+}
+module.exports = { search, multiSearch, extractInfoHash };

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -1,9 +1,9 @@
-// 0.33.0 — Stream handler. Companion-scraper architecture.
-// 0.34.0 — Added Pipeline C (direct Easynews search).
+// Stream handler.
 //
-// Three pipelines, run in parallel:
+// Three playback pipelines run in parallel. Pipeline A can discover torrents
+// through the companion scraper, direct Prowlarr, or both:
 //
-//   Pipeline A (debrid path): companion scraper -> noise + relevance
+//   Pipeline A (debrid path): torrent discovery -> noise + relevance
 //     filter -> sort -> TorBox cache check (per-user key) -> request
 //     playable URL for each cached hash -> URL stream rows.
 //     Uncached hashes are silently dropped — no infoHash rows ever leave
@@ -23,7 +23,7 @@
 //     `easynewsUsername`+`easynewsPassword` on /account.
 //
 // Admin requirements:
-//   - Companion scraper URL (for Pipeline A).
+//   - Companion scraper URL and/or direct Prowlarr URL + API key (Pipeline A).
 //   - Newsnab URL + API key (for Pipeline B).
 //   - (Easynews uses per-user creds only — no admin config.)
 
@@ -32,6 +32,7 @@ const { getByEventId } = require('./promotions');
 const newsnab = require('./sources/newsnab');
 const uu = require('./sources/usenet-ultimate');
 const companion = require('./sources/companion-scraper');
+const prowlarr = require('./sources/prowlarr');
 const easynews = require('./sources/easynews');
 const torbox = require('./sources/torbox-resolver');
 const settings = require('./settings');
@@ -256,18 +257,54 @@ function buildEasynewsRow(candidate, deferredUrl) {
 // Builds rows for every CACHED candidate, but does NOT call createTorrent
 // or requestdl. Those happen later, only if the user clicks Play, via the
 // /resolve route in addon.js -> resolvePlay() below.
-async function pipelineCompanionTorbox({ promo, event, titles, torboxKey, urlCtx, log }) {
+async function discoverTorrentCandidates({ promo, event, titles, log }) {
+  const tasks = [];
   const companionCfg = settings.getCompanion();
-  if (!companionCfg.url) { log('companion: not configured — skipping pipeline A'); return []; }
+  const prowlarrCfg = settings.getProwlarr();
+
+  if (companionCfg.url) {
+    tasks.push(companion.scrape({
+      promotion: promo, event, searchTitles: titles, log,
+    }).catch((err) => {
+      log('companion: search failed: ' + err.message);
+      return [];
+    }));
+  }
+  if (prowlarrCfg.url && prowlarrCfg.apiKey) {
+    log('prowlarr: searching ' + titles.length + ' title variant(s)');
+    tasks.push(prowlarr.multiSearch(titles, { log }).catch((err) => {
+      log('prowlarr: search failed: ' + err.message);
+      return [];
+    }));
+  }
+  if (tasks.length === 0) {
+    log('torrent discovery: no companion or direct Prowlarr configured');
+    return [];
+  }
+
+  const lists = await Promise.all(tasks);
+  const byHash = new Map();
+  for (const list of lists) {
+    for (const candidate of (list || [])) {
+      const hash = String(candidate.infoHash || '').toLowerCase();
+      if (!/^[a-f0-9]{40}$/.test(hash)) continue;
+      if (!byHash.has(hash)) byHash.set(hash, Object.assign({}, candidate, { infoHash: hash }));
+    }
+  }
+  const candidates = Array.from(byHash.values());
+  log('torrent discovery: ' + candidates.length + ' unique candidate(s)');
+  return candidates;
+}
+
+async function pipelineTorrentTorbox({ promo, event, titles, torboxKey, urlCtx, log }) {
   if (!torboxKey) { log('torbox: no user key — skipping pipeline A'); return []; }
 
-  // 1. Scrape (read-only — companion scraper has no side effects).
-  log('companion: scraping ' + titles.length + ' title variant(s)');
-  const candidates = await companion.scrape({ promotion: promo, event, searchTitles: titles, log });
+  // 1. Search the configured torrent sources. Both are read-only.
+  const candidates = await discoverTorrentCandidates({ promo, event, titles, log });
   if (candidates.length === 0) return [];
 
   // 2. Filter + sort (top N).
-  const relevant = filterCandidates('companion', candidates, log, promo, event);
+  const relevant = filterCandidates('torrent', candidates, log, promo, event);
   sortCandidates(relevant, 'size', 'publishDate');
   const top = relevant.slice(0, MAX_ROWS);
   if (top.length === 0) return [];
@@ -464,7 +501,7 @@ async function handleStream(params) {
   }
 
   const [torboxRows, uuRows, easynewsRows] = await Promise.all([
-    runOrSkip('torbox',   () => pipelineCompanionTorbox({ promo, event, titles, torboxKey, urlCtx, log })),
+    runOrSkip('torbox',   () => pipelineTorrentTorbox({ promo, event, titles, torboxKey, urlCtx, log })),
     runOrSkip('newsnab',  () => pipelineNewsnabUU({ promo, event, titles, uuConfig, log })),
     runOrSkip('easynews', () => pipelineEasynews({ promo, event, titles, easynewsCreds, urlCtx, log })),
   ]);
@@ -602,12 +639,9 @@ async function searchCandidates(event, log) {
     return [];
   }
   try {
-    const out = await companion.scrape({
-      promotion: promo, event, searchTitles: titles, log,
-    });
-    return Array.isArray(out) ? out : [];
+    return await discoverTorrentCandidates({ promo, event, titles, log });
   } catch (err) {
-    log('  searchCandidates: companion threw: ' + err.message);
+    log('  searchCandidates: torrent discovery threw: ' + err.message);
     return [];
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serioussportsync",
-  "version": "0.42.14",
+  "version": "0.42.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "serioussportsync",
-      "version": "0.42.14",
+      "version": "0.42.15",
       "license": "MIT",
       "dependencies": {
         "bcryptjs": "^2.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name":  "serioussportsync",
-    "version": "0.42.14",
+    "version": "0.42.15",
     "description":  "Self-hosted Stremio/Nuvio sports metadata calendar with optional per-user TorBox, Usenet Ultimate, and Easynews playback pipelines.",
     "main":  "server.js",
     "scripts":  {
@@ -19,6 +19,7 @@
                      "wwe",
                      "aew",
                      "torbox",
+                     "prowlarr",
                      "usenet",
                      "newznab",
                      "easynews",


### PR DESCRIPTION
## Summary

- restore direct Prowlarr URL and API-key configuration in the SeriousSportSync admin panel
- restore the real Prowlarr search adapter, hash extraction, and bounded download-proxy hydration
- combine and deduplicate direct Prowlarr and companion candidates before relevance filtering
- retain the TorBox-safe flow: cache check first, signed resolution on play, and no raw torrent rows
- expose Prowlarr configuration in health and manifest availability
- document admin/env configuration and bump the addon to 0.42.15

## Why

The settings model and power-tool hooks still referenced Prowlarr, but the admin fields had been removed and the source adapter was an empty compatibility stub. Re-adding only the fields would have produced a non-functional option.

## Validation

- repository-wide node --check
- mock Prowlarr API authentication, endpoint, normalization, and info-hash test
- end-to-end direct Prowlarr candidate discovery and deduplication smoke test
- settings persistence, manifest availability/privacy, and app-startup smoke test
- git diff --check
- Docker Compose and module tests will run in GitHub Actions