### PR TITLE
Keep direct Prowlarr request-only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,8 +88,10 @@ COMPANION_URL=
 COMPANION_AUTH_TOKEN=
 # COMPANION_TIMEOUT_MS=20000
 #
-# Optional direct Prowlarr alternative/supplement. These can also be saved in
-# Admin -> Torrent discovery and metadata sources, which overrides env values.
+# Optional direct Prowlarr alternative/supplement. Direct Prowlarr is searched
+# only when a user opens an event; the scheduled warmer never queries it.
+# These can also be saved in Admin -> Torrent discovery and metadata sources,
+# which overrides env values.
 PROWLARR_URL=
 PROWLARR_API_KEY=
 #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.42.16
+
+### Direct Prowlarr request boundary
+
+- Fixed direct Prowlarr being queried by the scheduled stream-cache warmer.
+- Direct Prowlarr now runs only for user event stream requests and explicit
+  admin live searches.
+- The warmer exits immediately when no companion scraper is configured,
+  preventing event-window fan-out and empty cache rewrites.
+
 ## 0.42.15
 
 ### Direct Prowlarr

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 >
 > 🎯 **Primarily designed for [Nuvio](https://github.com/zaarrak/Nuvio)** (a Stremio-compatible client). Also works with **Stremio** and other compatible clients.
 
-[![Version](https://img.shields.io/badge/version-0.42.15-blue.svg)](#)
+[![Version](https://img.shields.io/badge/version-0.42.16-blue.svg)](#)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 [![Nuvio](https://img.shields.io/badge/Nuvio-compatible-orange.svg)](#)
 [![Stremio Add-on](https://img.shields.io/badge/Stremio-compatible-7b5bf5.svg)](https://www.stremio.com/)
@@ -74,7 +74,7 @@ SeriousSportSync is a **sports metadata add-on, event calendar, and optional str
 
 The add-on can expose streams through the companion scraper and/or direct Prowlarr with per-user TorBox credentials, direct Newznab search with per-user Usenet Ultimate credentials, and per-user Easynews search.
 
-Prowlarr can be configured directly in the SeriousSportSync admin panel or inside the optional companion scraper (`_scraper`). The companion remains useful when combining Prowlarr with Zilean and other discovery sources. Wikipedia is only an optional artwork fallback for selected promotions; it is never a stream source.
+Direct Prowlarr is searched only when a user opens an event; the scheduled cache warmer never queries it. Prowlarr can be configured directly in the SeriousSportSync admin panel or inside the optional companion scraper (`_scraper`). The companion remains useful when combining Prowlarr with Zilean and other discovery sources. Wikipedia is only an optional artwork fallback for selected promotions; it is never a stream source.
 
 ---
 

--- a/addon.js
+++ b/addon.js
@@ -1162,7 +1162,7 @@ function renderAdminPage(currentUser, opts) {
 
     +       '<hr class="my-4">'
     +       '<h4 class="mb-2">Direct Prowlarr (optional)</h4>'
-    +       '<p class="text-secondary small mb-3">Query Prowlarr directly from SeriousSportSync as an alternative or supplement to the companion scraper. Results are filtered and checked against each user\'s TorBox account; raw torrent rows are never returned. The URL must be reachable from this container. For a separate Dockge stack, use a shared Docker network or the server address; <code>localhost</code> refers to this container.</p>'
+    +       '<p class="text-secondary small mb-3">Query Prowlarr directly when a user opens an event. Direct Prowlarr is never used by the scheduled cache warmer. Results are filtered and checked against each user\'s TorBox account; raw torrent rows are never returned. The URL must be reachable from this container. For a separate Dockge stack, use a shared Docker network or the server address; <code>localhost</code> refers to this container.</p>'
     +       '<div class="mb-3">'
     +         '<label class="form-label">Prowlarr URL</label>'
     +         '<input class="form-control text-mono" type="url" name="prowlarrUrl" value="' + escapeHtml(_prowlarr.url) + '" placeholder="http://prowlarr:9696" autocomplete="off">'

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -615,16 +615,11 @@ function resolveEasynews({ eventId, token, creds, log }) {
   return { ok: true, url };
 }
 
-// 0.35.1: re-introduce searchCandidates for the warmer + power-tool consumers.
+// Candidate search for the companion-backed warmer and power-tool consumers.
 //
-// The 0.33.0 companion-scraper rewrite removed this function but its callers
-// (scripts/refresh-streams.js, lib/power-tool.js) were never updated to point
-// at the new companion.scrape entry-point. Result: the warmer crash-looped
-// with "searchCandidates is not a function" on every event whenever it was
-// triggered. We restore the function here as a thin wrapper around the
-// companion-scraper pipeline, returning candidates in the legacy shape
-// (infoHash + title + size + seeders + magnetTrackers + publishDate) the
-// warmer / power-tool expect.
+// This returns candidates in the legacy shape expected by those callers.
+// Direct Prowlarr is intentionally excluded: it is request-only and runs from
+// pipelineTorrentTorbox when a user opens an event.
 async function searchCandidates(event, log) {
   log = log || (() => {});
   if (!event || !event.id) return [];
@@ -638,10 +633,18 @@ async function searchCandidates(event, log) {
     log('  searchCandidates: no searchTitles for ' + event.id);
     return [];
   }
+  const companionCfg = settings.getCompanion();
+  if (!companionCfg.url) {
+    log('  searchCandidates: companion not configured — scheduled search skipped');
+    return [];
+  }
   try {
-    return await discoverTorrentCandidates({ promo, event, titles, log });
+    const out = await companion.scrape({
+      promotion: promo, event, searchTitles: titles, log,
+    });
+    return Array.isArray(out) ? out : [];
   } catch (err) {
-    log('  searchCandidates: torrent discovery threw: ' + err.message);
+    log('  searchCandidates: companion threw: ' + err.message);
     return [];
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serioussportsync",
-  "version": "0.42.15",
+  "version": "0.42.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "serioussportsync",
-      "version": "0.42.15",
+      "version": "0.42.16",
       "license": "MIT",
       "dependencies": {
         "bcryptjs": "^2.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name":  "serioussportsync",
-    "version": "0.42.15",
+    "version": "0.42.16",
     "description":  "Self-hosted Stremio/Nuvio sports metadata calendar with optional per-user TorBox, Usenet Ultimate, and Easynews playback pipelines.",
     "main":  "server.js",
     "scripts":  {

--- a/scripts/refresh-streams.js
+++ b/scripts/refresh-streams.js
@@ -13,6 +13,7 @@
 const fs = require('fs');
 const path = require('path');
 const config = require('../config');
+const settings = require('../lib/settings');
 const store = require('../lib/store');
 const streamcache = require('../lib/streamcache');
 const { searchCandidates } = require('../lib/streams');
@@ -53,6 +54,25 @@ async function runStreamRefresh(options) {
   const baseLog = opts.log || ((m) => console.log(m));
   const log = (m) => baseLog(redact(String(m)));
   const start = Date.now();
+
+  // Direct Prowlarr is strictly request-only. The proactive warmer is a
+  // companion-scraper feature and must not fan out searches across every
+  // event when only direct Prowlarr is configured.
+  if (!settings.getCompanion().url) {
+    log('[stream-refresh] skipped — companion scraper is not configured; direct Prowlarr is searched per event request only');
+    const status = {
+      lastRunStart: new Date(start).toISOString(),
+      lastRunEnd: new Date().toISOString(),
+      durationSeconds: 0,
+      warmed: 0,
+      failed: 0,
+      totalCands: 0,
+      skipped: true,
+      reason: 'companion-not-configured',
+    };
+    writeStatus(status);
+    return { ok: true, ...status };
+  }
 
   const events = (store.loadFromDisk().events || []).filter(withinRefreshWindow);
   log('[stream-refresh] warming ' + events.length + ' event(s) in window (-'


### PR DESCRIPTION
## Summary

- remove direct Prowlarr from the shared background candidate-search helper
- make the scheduled stream warmer exit immediately when no companion scraper is configured
- retain direct Prowlarr for real event stream requests and explicit admin live searches
- document the request-only boundary and release it as 0.42.16

## Root cause

The 0.42.15 implementation reused discoverTorrentCandidates() from both the event stream pipeline and searchCandidates(). The latter is called by refresh-streams.js for every event in the warm window, causing direct Prowlarr to fan out across 142 events after startup.

## Validation

- regression test confirmed the warmer and searchCandidates issue zero Prowlarr requests
- the same test confirmed an actual event stream request queries Prowlarr, checks TorBox, and returns a cached stream row
- repository-wide node --check
- git diff --check
- GitHub Compose and module checks will run on this pull request