### PR TITLE
fix: remove direct Prowlarr category filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.42.17
+
+### Broader direct Prowlarr discovery
+
+- Removed the forced Movies, TV, and Other category filters from direct Prowlarr searches.
+- Prowlarr indexers such as Bitmagnet can now return results from their full text-search index.
+- SeriousSportSync still applies its promotion relevance filtering before showing streams.
+
 ## 0.42.16
 
 ### Direct Prowlarr request boundary

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 >
 > 🎯 **Primarily designed for [Nuvio](https://github.com/zaarrak/Nuvio)** (a Stremio-compatible client). Also works with **Stremio** and other compatible clients.
 
-[![Version](https://img.shields.io/badge/version-0.42.16-blue.svg)](#)
+[![Version](https://img.shields.io/badge/version-0.42.17-blue.svg)](#)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 [![Nuvio](https://img.shields.io/badge/Nuvio-compatible-orange.svg)](#)
 [![Stremio Add-on](https://img.shields.io/badge/Stremio-compatible-7b5bf5.svg)](https://www.stremio.com/)

--- a/lib/sources/prowlarr.js
+++ b/lib/sources/prowlarr.js
@@ -20,7 +20,6 @@ async function search(query, options) {
   const params = new URLSearchParams({
     query, type: 'search', limit: String(opts.limit || 100),
   });
-  for (const cat of ['2000', '5000', '8000']) params.append('categories', cat);
 
   const url = pw.url.replace(/\/$/, '') + '/api/v1/search?' + params.toString();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serioussportsync",
-  "version": "0.42.16",
+  "version": "0.42.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "serioussportsync",
-      "version": "0.42.16",
+      "version": "0.42.17",
       "license": "MIT",
       "dependencies": {
         "bcryptjs": "^2.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name":  "serioussportsync",
-    "version": "0.42.16",
+    "version": "0.42.17",
     "description":  "Self-hosted Stremio/Nuvio sports metadata calendar with optional per-user TorBox, Usenet Ultimate, and Easynews playback pipelines.",
     "main":  "server.js",
     "scripts":  {


### PR DESCRIPTION
## What changed

- Removed the forced Movies, TV, and Other categories from direct Prowlarr searches.
- Bumped SeriousSportSync to 0.42.17 and documented the discovery change.

## Why

Bitmagnet can return additional relevant sports releases when Prowlarr performs an unrestricted text search. SeriousSportSync was supplying fixed category filters on every request, preventing those releases from being returned even though the add-on's own promotion relevance filter would safely reject unrelated results.

## Validation

- Node syntax check passed for lib/sources/prowlarr.js.
- Mock Prowlarr request confirmed query, type=search, and limit=100 remain present.
- Mock request confirmed no categories parameter is sent.
- Git diff formatting check passed.