### PR TITLE
docs: refresh project front page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,70 @@
   <img src="public/logo-banner.png" alt="SeriousSportSync" width="820">
 </p>
 
-# 📅 SeriousSportSync — Sports Metadata & Calendar Add-on
+<p align="center">
+  A self-hosted sports calendar and stream orchestrator for Nuvio, Stremio,
+  and other Stremio-compatible clients.
+</p>
 
-> A self-hosted Stremio/Nuvio sports calendar with rich event metadata and optional, user-configured playback through TorBox, Usenet Ultimate, and Easynews.
->
-> 🎯 **Primarily designed for [Nuvio](https://github.com/zaarrak/Nuvio)** (a Stremio-compatible client). Also works with **Stremio** and other compatible clients.
+<p align="center">
+  <a href="https://github.com/Monkfish1337/Serioussportsync/releases"><img src="https://img.shields.io/badge/version-0.42.17-blue.svg" alt="Version 0.42.17"></a>
+  <a href="https://github.com/Monkfish1337/Serioussportsync/actions/workflows/ci.yml"><img src="https://github.com/Monkfish1337/Serioussportsync/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/Monkfish1337/Serioussportsync/pkgs/container/serioussportsync"><img src="https://img.shields.io/badge/GHCR-container-2496ED?logo=docker&logoColor=white" alt="Container image"></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="MIT license"></a>
+</p>
 
-[![Version](https://img.shields.io/badge/version-0.42.17-blue.svg)](#)
-[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
-[![Nuvio](https://img.shields.io/badge/Nuvio-compatible-orange.svg)](#)
-[![Stremio Add-on](https://img.shields.io/badge/Stremio-compatible-7b5bf5.svg)](https://www.stremio.com/)
+SeriousSportSync turns sports events into proper catalog items with dates,
+artwork, metadata, and optional playback results. It is primarily designed for
+[Nuvio](https://github.com/zaarrak/Nuvio), and also works with Stremio and
+compatible clients.
 
----
+It hosts no media. Every playback connector is optional, self-hosted or
+user-supplied, and remains under the operator's control.
 
-## 🐳 Docker Compose
+## Why SeriousSportSync?
 
-Create a directory for the addon and save this as `docker-compose.yml`:
+- Browse upcoming and recent events as first-class catalog entries.
+- Cover sports that general movie and television metadata providers handle poorly.
+- Search each event using promotion-aware names, dates, rounds, sessions, and matchups.
+- Reject interviews, countdown shows, wrong years, wrong rounds, and unrelated releases.
+- Give every account its own private install URL, catalogs, and playback credentials.
+- Add simple TSDB-backed sports and tune matching rules from the admin interface.
+- Deploy and update with Docker Compose while preserving state in a named volume.
 
-```yaml
+## Supported sports
+
+| Sport | Coverage |
+| --- | --- |
+| UFC | PPVs, Fight Nights, UFC on ABC/ESPN, DWCS |
+| ONE Championship | Numbered events, Fight Night, Friday Fights |
+| WWE | PLEs, named NXT events, Saturday Night's Main Event |
+| AEW | PPVs and Zero Hour pre-shows |
+| Formula 1 | Race, qualifying, sprint, sprint qualifying, and practice sessions |
+| MotoGP | Race, qualifying, sprint, and per-round sessions |
+| Boxing | Cards from major promoters |
+| Custom promotions | TSDB, football-data.org, or TMDB-backed catalogs created in the admin UI |
+
+## Playback integrations
+
+Playback is optional. SeriousSportSync can combine multiple pipelines and
+returns only the rows that finish within the configured request budget.
+
+| Discovery | Per-user playback | How it works |
+| --- | --- | --- |
+| Direct Prowlarr | TorBox | Searches when an event is opened, checks the user's cache, and resolves on play |
+| Companion scraper | TorBox | Combines Prowlarr, Zilean, Torznab, and other configured companion sources |
+| Newznab indexers | Usenet Ultimate | Searches configured Usenet sources and hands results to the user's UU instance |
+| Easynews | Easynews | Searches and plays with credentials stored on the user's account |
+
+Credentials are encrypted at rest where applicable and are never included in
+the stream list returned to the client. TorBox and Easynews playback use signed,
+short-lived resolve URLs.
+
+## Quick start with Docker Compose
+
+Create a directory and save the following as <code>docker-compose.yml</code>:
+
+~~~yaml
 services:
   serioussportsync:
     image: ghcr.io/monkfish1337/serioussportsync:latest
@@ -34,170 +80,123 @@ services:
 
 volumes:
   serioussportsync_data:
-```
+~~~
 
-Create the required environment file, then start the container:
+Create <code>.env</code> with a random session secret and your intended
+administrator username:
 
-```bash
-printf "SESSION_SECRET=%s\nADMIN_USER=admin\n" "$(openssl rand -hex 32)" > .env
+~~~env
+SESSION_SECRET=replace-with-at-least-32-random-characters
+ADMIN_USER=admin
+~~~
+
+Generate a suitable secret with <code>openssl rand -hex 32</code>, then start
+the stack:
+
+~~~bash
 docker compose up -d
-```
+~~~
 
-Open `http://<your-server>:7000/`, create the administrator account using
-the `ADMIN_USER` name, and copy its private install URL into Nuvio or Stremio.
+Open <code>http://&lt;your-server&gt;:7000/</code>, create the account matching
+<code>ADMIN_USER</code>, configure discovery services under Admin, then copy
+your private install URL from Account into Nuvio or Stremio.
 
-The image is public and supports normal `docker compose pull` updates. See the
-repository's complete [`docker-compose.yml`](./docker-compose.yml) and
-[`.env.example`](./.env.example) for optional metadata and playback settings.
+If port 7000 is occupied, change only the host side, for example
+<code>"7010:7000"</code>.
 
----
+The repository includes ready-to-use [docker-compose.yml](./docker-compose.yml)
+and [.env.example](./.env.example) files with the complete configuration
+surface.
 
-## ⚠️ Disclaimer
+## Updating
 
-> This project is a **sports metadata catalog and stream orchestrator**, published strictly for **educational** purposes.
->
-> SeriousSportSync **hosts no content**, bundles **no service credentials or indexer accounts**, and has **no affiliation** with any sport, league, broadcaster, or service. Playback connectors are optional and use accounts supplied by each user. The operator is solely responsible for ensuring their use complies with applicable laws and third-party terms.
-
----
-
-## ✨ What it does
-
-SeriousSportSync is a **sports metadata add-on, event calendar, and optional stream orchestrator** for Stremio-compatible clients.
-
-- 📅 **Calendar of upcoming events** for every supported sport — see what's airing this week or next month, browsable in Discover.
-- 🏷️ **Proper meta items** for sports events that mainstream meta providers (IMDb / TMDb) don't index — so they actually appear as first-class entries rather than being unfindable.
-- 🔎 **Smart per-event search aliases** built into each promotion (number, year, matchup, session).
-- 🧩 **Custom promotions and match overrides** managed from the admin UI without editing code.
-- 👤 **Per-user playback credentials** for shared deployments.
-
-### Current playback architecture
-
-The add-on can expose streams through the companion scraper and/or direct Prowlarr with per-user TorBox credentials, direct Newznab search with per-user Usenet Ultimate credentials, and per-user Easynews search.
-
-Direct Prowlarr is searched only when a user opens an event; the scheduled cache warmer never queries it. Prowlarr can be configured directly in the SeriousSportSync admin panel or inside the optional companion scraper (`_scraper`). The companion remains useful when combining Prowlarr with Zilean and other discovery sources. Wikipedia is only an optional artwork fallback for selected promotions; it is never a stream source.
-
----
-
-## 🏆 Covered sports
-
-| Sport | Events | Catalogs |
-|-------|--------|----------|
-| 🥋 **UFC** | PPVs, Fight Nights, UFC on ABC/ESPN, DWCS | Recent + Upcoming |
-| 🥊 **ONE Championship** | Numbered events, Fight Night, Friday Fights | Recent + Upcoming |
-| 🎤 **WWE** | PLEs, named NXT events, Saturday Night's Main Event, Main Event mini-PLEs | Recent + Upcoming |
-| 🤼 **AEW** | PPVs + Zero Hour pre-shows | Recent + Upcoming |
-| 🏎️ **Formula 1** | Per-session items per Grand Prix weekend | Upcoming + per-session catalogs |
-| 🏁 **MotoGP** | Per-session items per round | Upcoming + per-session catalogs |
-| 🥊 **Boxing** | Cards from major promoters | Recent + Upcoming |
-
-Adding another sport is a single self-contained entry in `lib/promotions.js`.
-
----
-
-## 🚀 Deployment and updates
-
-The container listens on `:7000`. Accounts, event data, and settings persist
-in the `serioussportsync_data` volume.
-
-### Updating a Docker deployment
-
-Once the repository is cloned on the server, future updates do not require
-copying application files:
-
-```bash
-git pull
+~~~bash
 docker compose pull
 docker compose up -d --remove-orphans
-```
+~~~
 
-Compose pulls and replaces the application container while keeping accounts,
-event data, and settings in the `serioussportsync_data` volume. Check the
-rollout with `docker compose ps` and `docker compose logs -f serioussportsync`.
+The named volume preserves accounts, event data, settings, custom promotions,
+and matching overrides across container replacements.
 
-### Local source builds
+## How it fits together
 
-Developers can build the checked-out source by layering the development
-override over the normal deployment file:
+~~~text
+Metadata sources -> event catalog -> promotion-aware matching -> stream rows
+                                             |                  |
+                                             |                  +-> per-user playback service
+                                             +-> noise, year, date, round, and session filters
+~~~
 
-```bash
-docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
-```
+- Metadata refreshes populate the event calendar independently of playback.
+- Opening an event creates short, release-friendly search variants.
+- Discovery sources return candidates; SeriousSportSync applies promotion rules.
+- The user's configured service resolves the selected result only when needed.
 
----
+Direct Prowlarr is request-only and is not searched by the scheduled cache
+warmer. The optional companion is useful when several discovery sources need to
+be combined behind one endpoint.
 
-## ⚙️ Configuration
+## Administration
 
-Env-driven with sensible defaults. See [`.env.example`](./.env.example) for the full annotated list.
+The web interface is designed so routine operation does not require editing
+JSON or application code.
+
+- **Dashboard:** refresh metadata, inspect service health, and review state.
+- **Services:** configure direct Prowlarr, the companion scraper, and Newznab.
+- **Users:** create invites and manage shared deployments.
+- **Match editor:** add aliases or noise rules and test a release before saving.
+- **Promotions creator:** add TSDB, football-data.org, or TMDB-backed sports.
+- **Event power tool:** run an explicit event search and inspect matching results.
+- **Logs:** inspect discovery, filtering, cache checks, and playback resolution.
+
+Changes made by the match editor and promotions creator are stored under
+<code>/app/data</code> and take effect without rebuilding the image.
+
+## Configuration highlights
+
+See [.env.example](./.env.example) for the annotated full list.
 
 | Variable | Default | Purpose |
-|----------|---------|---------|
-| `SESSION_SECRET` | _(required, ≥32 chars)_ | Signs login cookies. Generate with `openssl rand -hex 32`. |
-| `ADMIN_USER` | — | Username auto-promoted to admin on first signup. |
-| `LOGIN_MAX_FAILS` / `LOGIN_WINDOW_MS` / `LOGIN_LOCKOUT_MS` | `5` / `900000` / `900000` | Per-IP login rate-limit. |
-| `EVENT_WINDOW_START_DATE` | `2025-01-01` | Earliest date included in the catalog window. |
-| `REFRESH_INTERVAL_HOURS` | `6` | How often the metadata cache is refreshed from upstream sources. |
-| `TSDB_API_KEY` | `3` | TheSportsDB metadata key. |
-| `FOOTBALL_DATA_API_KEY` | — | Optional football-data.org source for custom promotions. |
-| `TMDB_API_KEY` | — | Optional TMDB source for custom promotions. |
-| `COMPANION_URL` | — | Optional companion scraper endpoint for TorBox playback. |
-| `PROWLARR_URL` / `PROWLARR_API_KEY` | — | Optional direct Prowlarr source; can instead be saved in the admin panel. |
-| `NEWSNAB_URL` / `NEWSNAB_API_KEY` | — | Optional direct Newznab endpoint for Usenet Ultimate playback. |
-| `STREAM_MAX_ROWS` | `20` | Maximum stream rows returned per request. |
-| `WIKIPEDIA_ENRICH` | `on` | Optional poster fallback for selected promotions only. |
-| `STREAM_CACHE_REFRESH` | `on` | Refresh cached stream results in the background. |
+| --- | --- | --- |
+| <code>SESSION_SECRET</code> | required | Signs login cookies; use at least 32 random characters |
+| <code>ADMIN_USER</code> | none | Username promoted to administrator during initial signup |
+| <code>PUBLIC_URL</code> | auto-detected | Public origin used for private install and resolve URLs |
+| <code>REFRESH_INTERVAL_HOURS</code> | <code>6</code> | Metadata refresh interval |
+| <code>EVENT_WINDOW_START_DATE</code> | <code>2025-01-01</code> | Earliest catalog date |
+| <code>COMPANION_URL</code> | none | Optional SeriousSportScraper companion endpoint |
+| <code>PROWLARR_URL</code> / <code>PROWLARR_API_KEY</code> | none | Optional direct Prowlarr discovery |
+| <code>NEWSNAB_URL</code> / <code>NEWSNAB_API_KEY</code> | none | Optional Newznab discovery for UU playback |
+| <code>STREAM_MAX_ROWS</code> | <code>20</code> | Maximum stream rows returned per request |
+| <code>STREAM_PIPELINE_TIMEOUT_MS</code> | <code>8000</code> | Maximum time allowed for each playback pipeline |
 
-Users add their own TorBox, Usenet Ultimate, and Easynews credentials from their account page. Companion-managed Prowlarr/Zilean settings belong in `_scraper/.env`; a direct Prowlarr connection belongs in the SeriousSportSync admin panel or root environment.
+Users configure their own TorBox, Usenet Ultimate, and Easynews credentials on
+the Account page. Server-wide discovery credentials belong in Admin or the root
+environment. Companion-managed sources belong in the companion's own settings.
 
----
+## Development
 
-## 🛠️ Admin tools (since 0.35.0)
+Build the local checkout with the development override:
 
-Two GUI tools under `/admin` let you tune matching and add new sports without code changes.
+~~~bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build
+~~~
 
-### Match editor (`/admin/match-editor`)
+For a bespoke built-in promotion, add a self-contained definition to
+<code>lib/promotions.js</code>. Simple metadata-backed sports should normally be
+added from the Promotions creator instead.
 
-Per-promotion editor for matching rules. Add release-name aliases or noise-rejection patterns when a real release is being incorrectly rejected. Includes a test bench: paste a release title, pick an event, see whether it would match before saving.
+Pull requests run JavaScript/module-load validation and a Docker Compose smoke
+deployment. Merges to <code>main</code> publish the public container image to
+GHCR and test that image through Compose.
 
-- **Location aliases** — for MotoGP (more promotions coming). If the TSDB event is "United Kingdom" but releases call it "BritishGP" or "Silverstone", add those aliases on the row for "united kingdom".
-- **Noise patterns** — extra regex patterns applied per-promotion during the noise filter stage. Use sparingly; the global defaults already cover vlogs, interviews, press conferences, etc.
-- **Hot-reload** — saving writes `data/match-overrides.json` and takes effect on the next `/stream` call. No container restart.
-- **Defaults are additive** — overrides extend, never replace, the built-in tables. Clearing all overrides reverts to defaults.
+## Responsible use
 
-### Promotions creator (`/admin/promotions`)
-
-Add new sports without writing code. Works for any TSDB-tracked sport with simple name-based matching (NFL, NBA, MLB, NHL, soccer leagues, regional MMA promotions, etc.). Bespoke promotions like UFC / F1 / MotoGP / WWE / AEW / Boxing / ONE keep their hand-written matching in code — the generic template doesn't try to replace them.
-
-- Built-in promotions show as **read-only** in the list (tagged "built-in").
-- Custom promotions are tagged "custom" and have Edit / Delete buttons.
-- The "Check TSDB" button on the add/edit form sanity-checks the league id against TSDB and returns a sample of recent events so you know you typed the right id (e.g. 4391 = NFL, 4387 = NBA, 4424 = MLB, 4380 = NHL, 4328 = English Premier League).
-- New promotions appear immediately in the catalog list. Run a refresh from `/admin` to populate their events.
-- Stored at `data/custom-promotions.json` — backed up alongside other state.
-
----
-
-## 🧩 Adding a promotion (in code)
-
-For sports needing bespoke matching logic (numbered events, multiple sessions per round, complex name parsing), add to `lib/promotions.js`. For TSDB-tracked sports with simple name matching, prefer the [Promotions creator](#promotions-creator-adminpromotions) above — no code or redeploy needed.
-
-A promotion is a self-contained config object in `lib/promotions.js`:
-
-- `id` / `idPrefix` / `name` — identifiers
-- `source` — `{ type: 'thesportsdb', leagueId: '...' }` for TSDB-sourced sports, or a custom source module
-- `classify(name)` — bucketise event types (PPV / Fight Night / Race / etc.)
-- `shortHandle(name)` — short canonical event handle
-- `searchTitles(event)` — array of short scene-style queries
-- `isRelevantStreamTitle(title, event)` — relevance filter
-- `buildAliases(name)` — full alias list
-- `catalogs` — array of `{ id, name, filter, sort }` for the catalogs the promotion exposes
-- `defaults` — fallback poster / fanart / logo
-- `includeEvent(ev)` — boolean filter applied at refresh time
-- `genres(ev)` — Stremio genres for the meta item
-- `expandEvents(events)` — *(optional)* synthesise derived events from the source's data
-
-Add the new promotion to the `all` array at the bottom of the file. Catalog, meta, and stream routes wire up automatically.
-
----
+SeriousSportSync is a metadata catalog and stream orchestrator published for
+educational and personal self-hosting use. It hosts no content, includes no
+third-party credentials, and is not affiliated with any sport, league,
+broadcaster, indexer, debrid provider, or media service. Operators are
+responsible for complying with applicable laws and service terms.
 
 ## License
 
-MIT — see [LICENSE](./LICENSE).
+[MIT](./LICENSE)


### PR DESCRIPTION
## What changed

- Reframed the front page around the project's current purpose and audience.
- Added clear supported-sports and playback-integration tables.
- Reworked Docker Compose into a conventional quick-start flow.
- Documented updates, request flow, administration, configuration, development, and responsible use.
- Added live CI and container-package badges.
- Removed stale detail and corrected the README's previous character-encoding artifacts.

## Validation

- README is the only changed file.
- Git whitespace validation passes.
- Referenced repository files and workflows exist.
- Current version, container path, ports, environment variables, sports, and integrations were checked against the repository.