### PR TITLE
Add Content Studio event curation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,8 @@ TSDB_SEASONS=auto
 EVENT_WINDOW_DAYS_BACK=30
 EVENT_WINDOW_DAYS_AHEAD=90
 # EVENT_WINDOW_START_DATE=2025-01-01
+# Optional override for Content Studio's refresh-safe editorial state.
+# CONTENT_STUDIO_FILE=./data/content-studio.json
 # Metadata refresh cadence in hours (0 disables the scheduler).
 REFRESH_INTERVAL_HOURS=6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.43.0
+
+### Content Studio
+
+- Added a promotion overview with visible, manual, and review-pending counts.
+- Added refresh-safe manual events, source-event overrides, disabling,
+  restoring, resetting, and deletion controls.
+- Added a missing-event inbox for promotion-filter rejections and possible
+  duplicates, with accept, merge, and ignore decisions.
+- Added previewed ICS, CSV, and JSON event imports.
+- Added guided matching suggestions that turn good and bad release examples
+  into per-event search aliases and exclusion patterns.
+- Added searchable TheSportsDB, football-data.org, and TMDB source discovery
+  to a simplified promotion wizard, while keeping the advanced editor.
+- Stored editorial content separately from the refreshed source cache so
+  catalog refreshes cannot overwrite manual work.
+
 ## 0.42.17
 
 ### Broader direct Prowlarr discovery

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Monkfish1337/Serioussportsync/releases"><img src="https://img.shields.io/badge/version-0.42.17-blue.svg" alt="Version 0.42.17"></a>
+  <a href="https://github.com/Monkfish1337/Serioussportsync/releases"><img src="https://img.shields.io/badge/version-0.43.0-blue.svg" alt="Version 0.43.0"></a>
   <a href="https://github.com/Monkfish1337/Serioussportsync/actions/workflows/ci.yml"><img src="https://github.com/Monkfish1337/Serioussportsync/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://github.com/Monkfish1337/Serioussportsync/pkgs/container/serioussportsync"><img src="https://img.shields.io/badge/GHCR-container-2496ED?logo=docker&logoColor=white" alt="Container image"></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="MIT license"></a>
@@ -146,11 +146,19 @@ JSON or application code.
 - **Users:** create invites and manage shared deployments.
 - **Match editor:** add aliases or noise rules and test a release before saving.
 - **Promotions creator:** add TSDB, football-data.org, or TMDB-backed sports.
+- **Content Studio:** search metadata sources, review promotion coverage, add or
+  edit events, and disable unwanted entries without losing changes on refresh.
+- **Missing event inbox:** accept, merge, or ignore source events rejected by
+  promotion filters and possible duplicate detection.
+- **Imports and matching assistant:** preview ICS, CSV, or JSON calendars, then
+  derive event-specific search aliases and exclusions from good and bad titles.
 - **Event power tool:** run an explicit event search and inspect matching results.
 - **Logs:** inspect discovery, filtering, cache checks, and playback resolution.
 
-Changes made by the match editor and promotions creator are stored under
-<code>/app/data</code> and take effect without rebuilding the image.
+Content Studio uses a separate editorial layer under <code>/app/data</code>.
+Source refreshes can replace their event cache without overwriting manual
+events, source-event edits, disabled-event decisions, or matching rules. Changes
+take effect without rebuilding the image.
 
 ## Configuration highlights
 
@@ -163,6 +171,7 @@ See [.env.example](./.env.example) for the annotated full list.
 | <code>PUBLIC_URL</code> | auto-detected | Public origin used for private install and resolve URLs |
 | <code>REFRESH_INTERVAL_HOURS</code> | <code>6</code> | Metadata refresh interval |
 | <code>EVENT_WINDOW_START_DATE</code> | <code>2025-01-01</code> | Earliest catalog date |
+| <code>CONTENT_STUDIO_FILE</code> | <code>./data/content-studio.json</code> | Refresh-safe manual content and editorial decisions |
 | <code>COMPANION_URL</code> | none | Optional SeriousSportScraper companion endpoint |
 | <code>PROWLARR_URL</code> / <code>PROWLARR_API_KEY</code> | none | Optional direct Prowlarr discovery |
 | <code>NEWSNAB_URL</code> / <code>NEWSNAB_API_KEY</code> | none | Optional Newznab discovery for UU playback |

--- a/addon.js
+++ b/addon.js
@@ -102,7 +102,9 @@ function createApp() {
   const app = express();
   app.disable('x-powered-by');
 
-  app.use(express.urlencoded({ extended: false, limit: '16kb' }));
+  // Content Studio imports are still plain text forms, but calendar files can
+  // reasonably exceed the old settings-only 16 KB ceiling.
+  app.use(express.urlencoded({ extended: false, limit: '1mb' }));
 
   // Attach req.user from session cookie if present.
   function loadSession(req, res, next) {
@@ -973,6 +975,162 @@ function createApp() {
     res.setHeader('Content-Type', 'application/json');
     res.setHeader('Cache-Control', 'no-store');
     res.send(JSON.stringify(out));
+  });
+
+  // --- Content Studio: refresh-safe event curation and guided setup -------
+  const contentStore = require('./lib/content-store');
+  const contentStudio = require('./lib/admin-content-studio');
+
+  function contentRedirect(tab, message, extra) {
+    const suffix = extra ? '&' + extra : '';
+    return '/admin/content?tab=' + encodeURIComponent(tab)
+      + '&flash=' + encodeURIComponent(message) + suffix;
+  }
+
+  app.get('/admin/content', requireAdmin, async (req, res) => {
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    res.setHeader('Cache-Control', 'no-store');
+    const view = {
+      tab: String(req.query.tab || 'overview'),
+      promo: String(req.query.promo || ''),
+      edit: String(req.query.edit || ''),
+      query: String(req.query.q || ''),
+      newEvent: req.query.new === '1',
+      flash: req.query.flash || null,
+      source: String(req.query.source || 'tsdb'),
+      sourceId: String(req.query.sourceId || ''),
+      name: String(req.query.name || ''),
+      discoveryQuery: String(req.query.query || ''),
+    };
+    if (view.tab === 'promotion' && req.query.discover === '1') {
+      try { view.discovery = await contentStudio.discoverSources(view.source, view.discoveryQuery); }
+      catch (err) { view.flash = 'Source search failed: ' + err.message; view.discovery = []; }
+    }
+    const body = contentStudio.renderBody(view);
+    res.send(tablerChrome.tablerPage('Content Studio', body, { user: req.user, currentSection: 'content' }));
+  });
+
+  app.post('/admin/content/events/create', requireAdmin, (req, res) => {
+    try {
+      const event = contentStore.upsertManual(req.body || {});
+      res.redirect(contentRedirect('events', 'Manual event added. It will survive source refreshes.', 'promo=' + encodeURIComponent(event.promotion)));
+    } catch (err) {
+      res.redirect(contentRedirect('events', 'Add failed: ' + err.message));
+    }
+  });
+
+  app.post('/admin/content/events/:id/save', requireAdmin, (req, res) => {
+    const id = String(req.params.id || '');
+    try {
+      const isManual = contentStore.load().manualEvents.some((x) => x.id === id);
+      if (isManual) contentStore.upsertManual(req.body || {}, id);
+      else contentStore.setOverride(id, req.body || {});
+      res.redirect(contentRedirect('events', isManual ? 'Manual event updated.' : 'Source event override saved. It will survive refreshes.', 'promo=' + encodeURIComponent(req.body.promotion || '')));
+    } catch (err) {
+      res.redirect(contentRedirect('events', 'Save failed: ' + err.message, 'edit=' + encodeURIComponent(id)));
+    }
+  });
+
+  app.post('/admin/content/events/:id/disable', requireAdmin, (req, res) => {
+    contentStore.setDisabled(String(req.params.id), true);
+    res.redirect(contentRedirect('events', 'Event disabled. You can restore it below the event list.'));
+  });
+  app.post('/admin/content/events/:id/enable', requireAdmin, (req, res) => {
+    contentStore.setDisabled(String(req.params.id), false);
+    res.redirect(contentRedirect('events', 'Event restored.'));
+  });
+  app.post('/admin/content/events/:id/delete', requireAdmin, (req, res) => {
+    const ok = contentStore.deleteManual(String(req.params.id));
+    res.redirect(contentRedirect('events', ok ? 'Manual event deleted.' : 'Only manual events can be deleted; source events can be disabled.'));
+  });
+  app.post('/admin/content/events/:id/reset', requireAdmin, (req, res) => {
+    contentStore.removeOverride(String(req.params.id));
+    res.redirect(contentRedirect('events', 'Source event restored to its original values.'));
+  });
+
+  app.post('/admin/content/inbox/:key/accept', requireAdmin, (req, res) => {
+    try {
+      const item = contentStore.load().inbox.find((x) => x.key === req.params.key);
+      if (!item) throw new Error('Inbox item not found.');
+      const created = contentStore.upsertManual(item.candidate);
+      contentStore.updateInbox(item.key, 'accepted', { createdEventId: created.id });
+      res.redirect(contentRedirect('inbox', 'Candidate accepted as a refresh-safe manual event.'));
+    } catch (err) { res.redirect(contentRedirect('inbox', 'Accept failed: ' + err.message)); }
+  });
+  app.post('/admin/content/inbox/:key/ignore', requireAdmin, (req, res) => {
+    try {
+      contentStore.updateInbox(String(req.params.key), 'ignored');
+      res.redirect(contentRedirect('inbox', 'Candidate ignored. It will not return on later refreshes.'));
+    } catch (err) { res.redirect(contentRedirect('inbox', 'Ignore failed: ' + err.message)); }
+  });
+  app.post('/admin/content/inbox/:key/merge', requireAdmin, (req, res) => {
+    try {
+      const targetId = String(req.body.targetId || '').trim();
+      const target = store.getEvent(targetId);
+      if (!target) throw new Error('Target event ID was not found.');
+      const item = contentStore.load().inbox.find((x) => x.key === req.params.key);
+      if (!item) throw new Error('Inbox item not found.');
+      const candidate = item.candidate || {};
+      contentStore.setOverride(targetId, {
+        searchAliases: [].concat(target.searchAliases || [], candidate.name || [], candidate.aliases || []),
+      });
+      contentStore.updateInbox(item.key, 'merged', { mergedInto: targetId });
+      res.redirect(contentRedirect('inbox', 'Candidate title merged into the existing event search aliases.'));
+    } catch (err) { res.redirect(contentRedirect('inbox', 'Merge failed: ' + err.message)); }
+  });
+
+  app.post('/admin/content/import/preview', requireAdmin, (req, res) => {
+    try {
+      const format = String(req.body.format || 'ics');
+      const content = String(req.body.content || '');
+      const promotion = String(req.body.promotion || '');
+      const records = contentStudio.parseImport(format, content);
+      const body = contentStudio.renderBody({ tab: 'import', preview: { format, content, promotion, records } });
+      res.send(tablerChrome.tablerPage('Content Studio', body, { user: req.user, currentSection: 'content' }));
+    } catch (err) { res.redirect(contentRedirect('import', 'Preview failed: ' + err.message)); }
+  });
+  app.post('/admin/content/import/apply', requireAdmin, (req, res) => {
+    try {
+      const records = contentStudio.parseImport(String(req.body.format || 'ics'), String(req.body.content || ''));
+      const result = contentStudio.applyImport(String(req.body.promotion || ''), records);
+      res.redirect(contentRedirect('events', 'Imported ' + result.added + ' event(s); skipped ' + result.skipped + ' invalid row(s).', 'promo=' + encodeURIComponent(req.body.promotion || '')));
+    } catch (err) { res.redirect(contentRedirect('import', 'Import failed: ' + err.message)); }
+  });
+
+  app.post('/admin/content/matching/suggest', requireAdmin, (req, res) => {
+    const eventId = String(req.body.eventId || '').trim();
+    if (!store.getEvent(eventId)) return res.redirect(contentRedirect('matching', 'Event ID not found.'));
+    const matchResult = {
+      eventId,
+      positive: String(req.body.positive || ''),
+      negative: String(req.body.negative || ''),
+      suggestions: contentStudio.suggestMatches(req.body.positive, req.body.negative),
+    };
+    const body = contentStudio.renderBody({ tab: 'matching', matchResult });
+    res.send(tablerChrome.tablerPage('Content Studio', body, { user: req.user, currentSection: 'content' }));
+  });
+  app.post('/admin/content/matching/apply', requireAdmin, (req, res) => {
+    try {
+      const id = String(req.body.eventId || '').trim();
+      if (!store.getEvent(id)) throw new Error('Event ID not found.');
+      contentStore.setOverride(id, { searchAliases: req.body.searchAliases, excludePatterns: req.body.excludePatterns });
+      res.redirect(contentRedirect('matching', 'Suggested rules applied to ' + id + '.'));
+    } catch (err) { res.redirect(contentRedirect('matching', 'Apply failed: ' + err.message)); }
+  });
+
+  app.post('/admin/content/promotions/create', requireAdmin, (req, res) => {
+    try {
+      const body = Object.assign({}, req.body || {});
+      const name = String(body.name || '').trim();
+      const source = String(body.source || 'tsdb');
+      body.searchTitleTemplates = String(body.searchTitleTemplates || '').trim() || '{name}\n{name} {year}';
+      body.relevanceKeywords = String(body.relevanceKeywords || '').trim() || [body.id, name].filter(Boolean).join(', ');
+      if (source === 'tsdb') body.leagueId = body.sourceId;
+      else if (source === 'football-data') body.competitionId = body.sourceId;
+      else if (source === 'tmdb') body.tvId = body.sourceId;
+      const spec = adminPromotions.saveFromForm(body);
+      res.redirect(contentRedirect('overview', 'Created ' + spec.name + '. Use Refresh on its card to fetch events.'));
+    } catch (err) { res.redirect(contentRedirect('promotion', 'Create failed: ' + err.message)); }
   });
 
   // --- Public invite redemption (no login required) ----------------

--- a/config.js
+++ b/config.js
@@ -65,6 +65,7 @@ module.exports = {
 
   includeContenderSeries: false,
   dataFile: process.env.DATA_FILE || './data/events.json',
+  contentStudioFile: process.env.CONTENT_STUDIO_FILE || './data/content-studio.json',
 
   // Sliding window of events kept in cache. Asymmetric so users can see
   // multiple upcoming events (promotions like ONE list 6+ months ahead)

--- a/lib/admin-content-studio.js
+++ b/lib/admin-content-studio.js
@@ -1,0 +1,246 @@
+const store = require('./store');
+const contentStore = require('./content-store');
+const promotions = require('./promotions');
+const { escapeHtml } = require('./tabler-chrome');
+const fetch = require('node-fetch');
+const config = require('../config');
+
+function e(value) { return escapeHtml(value == null ? '' : String(value)); }
+function selected(a, b) { return String(a || '') === String(b || '') ? ' selected' : ''; }
+function checked(v) { return v ? ' checked' : ''; }
+
+function parseCsv(text) {
+  const rows = [];
+  let row = [], field = '', quoted = false;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i], next = text[i + 1];
+    if (c === '"' && quoted && next === '"') { field += '"'; i++; }
+    else if (c === '"') quoted = !quoted;
+    else if (c === ',' && !quoted) { row.push(field); field = ''; }
+    else if ((c === '\n' || c === '\r') && !quoted) {
+      if (c === '\r' && next === '\n') i++;
+      row.push(field); field = '';
+      if (row.some((x) => String(x).trim())) rows.push(row);
+      row = [];
+    } else field += c;
+  }
+  row.push(field); if (row.some((x) => String(x).trim())) rows.push(row);
+  if (rows.length < 2) return [];
+  const headers = rows.shift().map((x) => String(x).trim().toLowerCase());
+  return rows.map((values) => Object.fromEntries(headers.map((h, i) => [h, values[i] || ''])));
+}
+
+function icsValue(line) {
+  const idx = line.indexOf(':');
+  return idx < 0 ? '' : line.slice(idx + 1).replace(/\\n/gi, '\n').replace(/\\,/g, ',').trim();
+}
+
+function icsDate(value) {
+  const v = String(value || '').trim();
+  const m = v.match(/^(\d{4})(\d{2})(\d{2})/);
+  return m ? m[1] + '-' + m[2] + '-' + m[3] : v;
+}
+
+function parseIcs(text) {
+  const unfolded = String(text || '').replace(/\r?\n[ \t]/g, '');
+  const blocks = unfolded.match(/BEGIN:VEVENT[\s\S]*?END:VEVENT/gi) || [];
+  return blocks.map((block) => {
+    const lines = block.split(/\r?\n/);
+    const find = (name) => {
+      const line = lines.find((l) => l.toUpperCase().startsWith(name + ':') || l.toUpperCase().startsWith(name + ';'));
+      return line ? icsValue(line) : '';
+    };
+    return { name: find('SUMMARY'), date: icsDate(find('DTSTART')), description: find('DESCRIPTION'), venue: find('LOCATION'), sourceId: find('UID') };
+  });
+}
+
+function parseImport(format, text) {
+  const raw = String(text || '').trim();
+  if (!raw) throw new Error('Paste or choose an import file first.');
+  let records;
+  if (format === 'ics') records = parseIcs(raw);
+  else if (format === 'csv') records = parseCsv(raw);
+  else {
+    const parsed = JSON.parse(raw);
+    records = Array.isArray(parsed) ? parsed : parsed.events;
+  }
+  if (!Array.isArray(records)) throw new Error('Import must contain an array of events.');
+  return records.slice(0, 500).map((r, index) => ({
+    row: index + 1,
+    name: String(r.name || r.title || r.summary || '').trim(),
+    date: icsDate(r.date || r.start || r.dtstart || ''),
+    time: String(r.time || '').trim(),
+    venue: String(r.venue || r.location || '').trim(),
+    description: String(r.description || '').trim(),
+    aliases: Array.isArray(r.aliases) ? r.aliases.join('\n') : String(r.aliases || ''),
+    searchAliases: Array.isArray(r.searchAliases) ? r.searchAliases.join('\n') : String(r.searchAliases || ''),
+    sourceId: String(r.sourceId || r.uid || '').trim(),
+    valid: !!String(r.name || r.title || r.summary || '').trim() && /^\d{4}-\d{2}-\d{2}$/.test(icsDate(r.date || r.start || r.dtstart || '')),
+  }));
+}
+
+function applyImport(promotionId, records) {
+  let added = 0, skipped = 0;
+  for (const record of records) {
+    if (!record.valid) { skipped++; continue; }
+    contentStore.upsertManual(Object.assign({}, record, { promotion: promotionId }));
+    added++;
+  }
+  return { added, skipped };
+}
+
+const STOP = new Set('the a an and or vs v at on in of for from full event episode night day live part show'.split(' '));
+function tokens(title) {
+  return String(title || '').toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim().split(/\s+/).filter((x) => x.length > 2 && !STOP.has(x) && !/^20\d\d$/.test(x));
+}
+function suggestMatches(positiveText, negativeText) {
+  const positives = String(positiveText || '').split(/\r?\n/).map((x) => x.trim()).filter(Boolean);
+  const negatives = String(negativeText || '').split(/\r?\n/).map((x) => x.trim()).filter(Boolean);
+  const negativeTokens = new Set(negatives.flatMap(tokens));
+  const counts = new Map();
+  for (const token of positives.flatMap(tokens)) counts.set(token, (counts.get(token) || 0) + 1);
+  const common = Array.from(counts.entries()).filter(([word, count]) => !negativeTokens.has(word) && count >= Math.max(1, Math.ceil(positives.length * 0.5))).sort((a,b) => b[1]-a[1]).map(([word]) => word);
+  const aliases = positives.slice(0, 8).map((x) => x.replace(/\b(2160p|1080p|720p|web[- .]?dl|webrip|hdtv|x26[45]|hevc|aac|proper|repack)\b/ig, '').replace(/[._]+/g, ' ').replace(/\s+/g, ' ').trim()).filter((x) => x.length >= 4);
+  const negativeDistinct = Array.from(negativeTokens).filter((x) => !counts.has(x)).slice(0, 12);
+  return { aliases: Array.from(new Set(aliases)).slice(0, 6), keywords: common.slice(0, 10), excludePatterns: negativeDistinct.map((x) => '\\b' + x.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\b') };
+}
+
+function promotionOptions(value) {
+  return promotions.all.map((p) => '<option value="' + e(p.id) + '"' + selected(p.id, value) + '>' + e(p.name) + '</option>').join('');
+}
+
+function nav(tab) {
+  const items = [['overview','Overview'],['events','Events'],['inbox','Missing inbox'],['import','Import'],['matching','Matching assistant'],['promotion','Add promotion']];
+  return '<ul class="nav nav-tabs mb-4">' + items.map(([id,label]) => '<li class="nav-item"><a class="nav-link' + (tab === id ? ' active' : '') + '" href="/admin/content?tab=' + id + '">' + label + '</a></li>').join('') + '</ul>';
+}
+
+function flashHtml(flash) {
+  return flash ? '<div class="alert alert-info alert-dismissible"><div>' + e(flash) + '</div><a class="btn-close" data-bs-dismiss="alert"></a></div>' : '';
+}
+
+function overview() {
+  const events = store.getEvents();
+  const state = contentStore.load();
+  const cards = promotions.all.map((p) => {
+    const count = events.filter((event) => event.promotion === p.id).length;
+    const manual = state.manualEvents.filter((event) => event.promotion === p.id).length;
+    const pending = state.inbox.filter((item) => item.status === 'pending' && item.candidate && item.candidate.promotion === p.id).length;
+    return '<div class="col-sm-6 col-xl-4"><div class="card h-100"><div class="card-body"><div class="d-flex justify-content-between"><h3 class="card-title">' + e(p.name) + '</h3><span class="badge ' + (p.isCustom ? 'bg-green-lt' : 'bg-blue-lt') + '">' + (p.isCustom ? 'custom' : 'built-in') + '</span></div><div class="text-secondary">' + count + ' visible · ' + manual + ' manual · ' + pending + ' to review</div></div><div class="card-footer"><a class="btn btn-sm btn-primary" href="/admin/content?tab=events&promo=' + encodeURIComponent(p.id) + '">Manage events</a> <form class="d-inline" method="POST" action="/admin/promotions/' + encodeURIComponent(p.id) + '/refresh"><button class="btn btn-sm btn-outline-info">Refresh</button></form></div></div></div>';
+  }).join('');
+  return '<div class="d-flex justify-content-between align-items-center mb-3"><div><h2 class="mb-1">Promotion overview</h2><p class="text-secondary mb-0">One place to see coverage, add missing events, and review source decisions.</p></div><a class="btn btn-primary" href="/admin/content?tab=events&new=1">Add event</a></div><div class="row g-3">' + cards + '</div>';
+}
+
+function eventForm(event, promoId, isManual) {
+  const item = event || {};
+  const action = item.id ? '/admin/content/events/' + encodeURIComponent(item.id) + '/save' : '/admin/content/events/create';
+  return '<div class="card mb-4"><div class="card-header"><h3 class="card-title">' + (item.id ? 'Edit event' : 'Add event') + '</h3></div><div class="card-body"><form method="POST" action="' + action + '"><div class="row g-3">'
+    + '<div class="col-md-4"><label class="form-label">Promotion</label><select class="form-select" name="promotion"' + (item.id ? ' disabled' : '') + '>' + promotionOptions(item.promotion || promoId) + '</select>' + (item.id ? '<input type="hidden" name="promotion" value="' + e(item.promotion) + '">' : '') + '</div>'
+    + '<div class="col-md-5"><label class="form-label">Event name</label><input class="form-control" required name="name" value="' + e(item.name) + '"></div>'
+    + '<div class="col-md-3"><label class="form-label">Date</label><input class="form-control" required type="date" name="date" value="' + e(item.date) + '"></div>'
+    + '<div class="col-md-3"><label class="form-label">Time (UTC)</label><input class="form-control" type="time" step="1" name="time" value="' + e(item.time) + '"></div>'
+    + '<div class="col-md-3"><label class="form-label">Kind</label><input class="form-control" name="kind" value="' + e(item.kind) + '" placeholder="event, ppv, race…"></div>'
+    + '<div class="col-md-3"><label class="form-label">Venue</label><input class="form-control" name="venue" value="' + e(item.venue) + '"></div>'
+    + '<div class="col-md-3"><label class="form-label">City</label><input class="form-control" name="city" value="' + e(item.city) + '"></div>'
+    + '<div class="col-md-6"><label class="form-label">Poster URL</label><input class="form-control" type="url" name="poster" value="' + e(item.poster) + '"></div>'
+    + '<div class="col-md-6"><label class="form-label">Background URL</label><input class="form-control" type="url" name="fanart" value="' + e(item.fanart) + '"></div>'
+    + '<div class="col-md-6"><label class="form-label">Alternate/search titles</label><textarea class="form-control" rows="4" name="searchAliases" placeholder="One exact search phrase per line">' + e((item.searchAliases || []).join('\n')) + '</textarea><small class="text-secondary">These are added to the normal event searches and can rescue valid releases rejected by the standard matcher.</small></div>'
+    + '<div class="col-md-6"><label class="form-label">Event-specific exclusions</label><textarea class="form-control text-mono" rows="4" name="excludePatterns" placeholder="One regular expression per line">' + e((item.excludePatterns || []).join('\n')) + '</textarea><small class="text-secondary">Only affects this event.</small></div>'
+    + '<div class="col-12"><label class="form-label">Description / editor notes</label><textarea class="form-control" rows="3" name="description">' + e(item.description) + '</textarea></div>'
+    + '</div><div class="mt-3"><button class="btn btn-primary">Save ' + (isManual ? 'manual event' : item.id ? 'override' : 'event') + '</button> <a class="btn btn-link" href="/admin/content?tab=events&promo=' + encodeURIComponent(item.promotion || promoId || '') + '">Cancel</a></div></form></div></div>';
+}
+
+function eventsPage(opts) {
+  const state = contentStore.load();
+  const promoId = opts.promo || (promotions.all[0] && promotions.all[0].id) || '';
+  const allEvents = store.getEvents();
+  const chosen = opts.edit ? allEvents.find((x) => x.id === opts.edit) : null;
+  const manualIds = new Set(state.manualEvents.map((x) => x.id));
+  let body = '<div class="d-flex flex-wrap gap-2 align-items-end mb-3"><form method="GET" action="/admin/content"><input type="hidden" name="tab" value="events"><label class="form-label">Promotion</label><div class="input-group"><select class="form-select" name="promo">' + promotionOptions(promoId) + '</select><button class="btn btn-outline-primary">Open</button></div></form><a class="btn btn-primary ms-auto" href="/admin/content?tab=events&promo=' + encodeURIComponent(promoId) + '&new=1">Add event</a></div>';
+  if (opts.newEvent || chosen) body += eventForm(chosen, promoId, chosen && manualIds.has(chosen.id));
+  const query = String(opts.query || '').toLowerCase();
+  const rows = allEvents.filter((x) => x.promotion === promoId && (!query || String(x.name).toLowerCase().includes(query))).slice(0, 300).map((item) => {
+    const manual = manualIds.has(item.id);
+    const overridden = !!state.eventOverrides[item.id];
+    return '<tr><td><strong>' + e(item.name) + '</strong><br><small class="text-secondary text-mono">' + e(item.id) + '</small></td><td>' + e(item.date) + '</td><td>' + (manual ? '<span class="badge bg-green-lt">manual</span>' : '<span class="badge bg-blue-lt">source</span>') + (overridden ? ' <span class="badge bg-yellow-lt">edited</span>' : '') + '</td><td class="text-nowrap"><a class="btn btn-sm btn-outline-primary" href="/admin/content?tab=events&promo=' + encodeURIComponent(promoId) + '&edit=' + encodeURIComponent(item.id) + '">Edit</a> <form class="d-inline" method="POST" action="/admin/content/events/' + encodeURIComponent(item.id) + '/disable"><button class="btn btn-sm btn-outline-warning">Disable</button></form>' + (manual ? ' <form class="d-inline" method="POST" action="/admin/content/events/' + encodeURIComponent(item.id) + '/delete" onsubmit="return confirm(\'Delete this manual event?\')"><button class="btn btn-sm btn-outline-danger">Delete</button></form>' : overridden ? ' <form class="d-inline" method="POST" action="/admin/content/events/' + encodeURIComponent(item.id) + '/reset"><button class="btn btn-sm btn-outline-secondary">Reset</button></form>' : '') + '</td></tr>';
+  }).join('');
+  body += '<div class="card"><div class="card-header"><h3 class="card-title">Events</h3><form class="ms-auto" method="GET"><input type="hidden" name="tab" value="events"><input type="hidden" name="promo" value="' + e(promoId) + '"><input class="form-control" name="q" value="' + e(opts.query) + '" placeholder="Filter events"></form></div><div class="table-responsive"><table class="table table-vcenter"><thead><tr><th>Event</th><th>Date</th><th>Origin</th><th></th></tr></thead><tbody>' + (rows || '<tr><td colspan="4" class="text-secondary">No events found.</td></tr>') + '</tbody></table></div></div>';
+  const disabled = state.disabledEventIds.map((id) => '<form class="d-inline me-2 mb-2" method="POST" action="/admin/content/events/' + encodeURIComponent(id) + '/enable"><button class="btn btn-sm btn-outline-secondary">Restore ' + e(id) + '</button></form>').join('');
+  if (disabled) body += '<div class="card mt-3"><div class="card-header"><h3 class="card-title">Disabled events</h3></div><div class="card-body">' + disabled + '</div></div>';
+  return body;
+}
+
+function inboxPage() {
+  const items = contentStore.load().inbox.filter((x) => x.status === 'pending');
+  const rows = items.map((item) => '<tr><td><strong>' + e(item.candidate.name) + '</strong><br><small class="text-secondary">' + e(item.candidate.promotion) + ' · ' + e(item.candidate.date) + '</small></td><td><span class="badge bg-yellow-lt">' + e(item.reason) + '</span><br><small>' + e(item.details) + '</small></td><td><form class="d-inline" method="POST" action="/admin/content/inbox/' + e(item.key) + '/accept"><button class="btn btn-sm btn-primary">Accept as manual</button></form> <form class="d-inline" method="POST" action="/admin/content/inbox/' + e(item.key) + '/ignore"><button class="btn btn-sm btn-outline-secondary">Ignore</button></form><form class="mt-2 d-flex gap-1" method="POST" action="/admin/content/inbox/' + e(item.key) + '/merge"><input class="form-control form-control-sm" name="targetId" placeholder="Existing event ID"><button class="btn btn-sm btn-outline-info">Merge</button></form></td></tr>').join('');
+  return '<div class="mb-3"><h2 class="mb-1">Missing event inbox</h2><p class="text-secondary">Events rejected by a promotion filter and likely duplicates appear here instead of disappearing silently.</p></div><div class="card"><div class="table-responsive"><table class="table table-vcenter"><thead><tr><th>Candidate</th><th>Why it needs review</th><th>Decision</th></tr></thead><tbody>' + (rows || '<tr><td colspan="3" class="text-secondary">Inbox clear. New source decisions appear after a refresh.</td></tr>') + '</tbody></table></div></div>';
+}
+
+function importPage(preview) {
+  let previewHtml = '';
+  if (preview && preview.records) {
+    const rows = preview.records.map((x) => '<tr><td>' + x.row + '</td><td>' + e(x.name) + '</td><td>' + e(x.date) + '</td><td>' + (x.valid ? '<span class="badge bg-green-lt">ready</span>' : '<span class="badge bg-red-lt">needs name/date</span>') + '</td></tr>').join('');
+    previewHtml = '<div class="card mt-3"><div class="card-header"><h3 class="card-title">Preview</h3></div><div class="table-responsive"><table class="table"><thead><tr><th>#</th><th>Name</th><th>Date</th><th>Status</th></tr></thead><tbody>' + rows + '</tbody></table></div><div class="card-footer"><form method="POST" action="/admin/content/import/apply"><input type="hidden" name="promotion" value="' + e(preview.promotion) + '"><input type="hidden" name="format" value="' + e(preview.format) + '"><textarea hidden name="content">' + e(preview.content) + '</textarea><button class="btn btn-primary">Import ' + preview.records.filter((x) => x.valid).length + ' valid events</button></form></div></div>';
+  }
+  return '<h2>Import events</h2><p class="text-secondary">Preview and validate calendar or spreadsheet data before it becomes manual content. Maximum 500 events per import.</p><div class="card"><div class="card-body"><form method="POST" action="/admin/content/import/preview"><div class="row g-3"><div class="col-md-4"><label class="form-label">Promotion</label><select class="form-select" name="promotion">' + promotionOptions(preview && preview.promotion) + '</select></div><div class="col-md-3"><label class="form-label">Format</label><select class="form-select" name="format"><option value="ics">ICS calendar</option><option value="csv">CSV</option><option value="json">JSON</option></select></div><div class="col-12"><label class="form-label">File or pasted content</label><input class="form-control mb-2" id="importFile" type="file" accept=".ics,.csv,.json,text/calendar,text/csv,application/json"><textarea class="form-control text-mono" id="importContent" name="content" rows="10" required placeholder="Choose a file or paste its contents here">' + e(preview && preview.content) + '</textarea></div></div><button class="btn btn-primary mt-3">Preview import</button></form></div></div>' + previewHtml + '<script>document.getElementById("importFile").addEventListener("change",function(){var f=this.files[0];if(!f)return;var r=new FileReader();r.onload=function(){document.getElementById("importContent").value=r.result};r.readAsText(f);});</script>';
+}
+
+function matchingPage(result) {
+  const r = result || {};
+  const suggestions = r.suggestions ? '<div class="card mt-3"><div class="card-header"><h3 class="card-title">Suggested event rules</h3></div><div class="card-body"><form method="POST" action="/admin/content/matching/apply"><input type="hidden" name="eventId" value="' + e(r.eventId) + '"><label class="form-label">Search aliases</label><textarea class="form-control" name="searchAliases" rows="5">' + e(r.suggestions.aliases.join('\n')) + '</textarea><label class="form-label mt-3">Exclude patterns</label><textarea class="form-control text-mono" name="excludePatterns" rows="5">' + e(r.suggestions.excludePatterns.join('\n')) + '</textarea><button class="btn btn-primary mt-3">Apply to event</button></form><div class="mt-3 text-secondary">Distinctive positive tokens: ' + e(r.suggestions.keywords.join(', ') || 'none found') + '</div></div></div>' : '';
+  return '<h2>Matching assistant</h2><p class="text-secondary">Paste examples that should and should not match. The assistant proposes event-specific searches and exclusions; nothing changes until you apply them.</p><div class="card"><div class="card-body"><form method="POST" action="/admin/content/matching/suggest"><div class="mb-3"><label class="form-label">Event ID</label><input class="form-control text-mono" required name="eventId" value="' + e(r.eventId) + '" placeholder="wwe:123456"></div><div class="row g-3"><div class="col-md-6"><label class="form-label">Correct release titles</label><textarea class="form-control text-mono" required name="positive" rows="9" placeholder="One title per line">' + e(r.positive) + '</textarea></div><div class="col-md-6"><label class="form-label">Incorrect release titles</label><textarea class="form-control text-mono" name="negative" rows="9" placeholder="One title per line">' + e(r.negative) + '</textarea></div></div><button class="btn btn-primary mt-3">Suggest rules</button></form></div></div>' + suggestions;
+}
+
+function promotionPage(opts) {
+  opts = opts || {};
+  const source = opts.source || 'tsdb';
+  const discovered = (opts.discovery || []).map((item) => '<tr><td><strong>' + e(item.name) + '</strong><br><small class="text-secondary">' + e(item.description) + '</small></td><td class="text-mono">' + e(item.id) + '</td><td><a class="btn btn-sm btn-primary" href="/admin/content?tab=promotion&source=' + encodeURIComponent(source) + '&sourceId=' + encodeURIComponent(item.id) + '&name=' + encodeURIComponent(item.name) + '">Use this source</a></td></tr>').join('');
+  const discovery = '<div class="card mb-3"><div class="card-header"><h3 class="card-title">Find a source</h3></div><div class="card-body"><form method="GET" action="/admin/content"><input type="hidden" name="tab" value="promotion"><input type="hidden" name="discover" value="1"><div class="row g-2"><div class="col-md-3"><select class="form-select" name="source"><option value="tsdb"' + selected(source,'tsdb') + '>TheSportsDB</option><option value="football-data"' + selected(source,'football-data') + '>football-data.org</option><option value="tmdb"' + selected(source,'tmdb') + '>TMDB TV show</option></select></div><div class="col-md-7"><input class="form-control" name="query" value="' + e(opts.discoveryQuery) + '" placeholder="Search by league, competition, or show name"></div><div class="col-md-2"><button class="btn btn-outline-primary w-100">Search</button></div></div></form></div>' + (opts.discovery ? '<div class="table-responsive"><table class="table"><tbody>' + (discovered || '<tr><td class="text-secondary">No matching sources found.</td></tr>') + '</tbody></table></div>' : '') + '</div>';
+  return '<h2>Add a promotion</h2><p class="text-secondary">Find the source by name, preview its ID, then create the promotion with practical matching defaults.</p>' + discovery + '<div class="card"><div class="card-body"><form method="POST" action="/admin/content/promotions/create"><div class="row g-3"><div class="col-md-4"><label class="form-label">Name</label><input class="form-control" required name="name" value="' + e(opts.name) + '" placeholder="National Football League"></div><div class="col-md-3"><label class="form-label">Short ID</label><input class="form-control" required pattern="[a-z0-9_-]{2,30}" name="id" placeholder="nfl"></div><div class="col-md-3"><label class="form-label">Source</label><select class="form-select" name="source" id="quickSource"><option value="tsdb"' + selected(source,'tsdb') + '>TheSportsDB</option><option value="football-data"' + selected(source,'football-data') + '>football-data.org</option><option value="tmdb"' + selected(source,'tmdb') + '>TMDB TV show</option></select></div><div class="col-md-2"><label class="form-label">Source ID</label><input class="form-control" required name="sourceId" value="' + e(opts.sourceId) + '" placeholder="4391"></div><div class="col-md-6"><label class="form-label">Poster URL (optional)</label><input class="form-control" type="url" name="poster"></div><div class="col-md-6"><label class="form-label">Background URL (optional)</label><input class="form-control" type="url" name="fanart"></div></div><details class="mt-3"><summary class="text-secondary">Advanced matching defaults</summary><div class="row g-3 mt-1"><div class="col-md-6"><label class="form-label">Search templates</label><textarea class="form-control" name="searchTitleTemplates" rows="3" placeholder="{name}\n{name} {year}"></textarea></div><div class="col-md-6"><label class="form-label">Relevance keywords</label><input class="form-control" name="relevanceKeywords" placeholder="nfl, football"></div></div></details><button class="btn btn-primary mt-3">Create promotion</button> <a class="btn btn-link" href="/admin/promotions">Open full advanced editor</a></form></div></div>';
+}
+
+async function discoverSources(source, query) {
+  const q = String(query || '').trim();
+  if (q.length < 2) throw new Error('Enter at least two characters to search.');
+  if (source === 'tsdb') {
+    const key = (config.tsdb && config.tsdb.apiKey) || '3';
+    const url = 'https://www.thesportsdb.com/api/v1/json/' + encodeURIComponent(key) + '/search_all_leagues.php?l=' + encodeURIComponent(q);
+    const response = await fetch(url, { headers: { 'User-Agent': 'serioussportsync/content-studio' }, timeout: 15000 });
+    if (!response.ok) throw new Error('TheSportsDB returned HTTP ' + response.status);
+    const json = await response.json();
+    return (json.countries || []).slice(0, 30).map((x) => ({ id: x.idLeague, name: x.strLeague, description: [x.strSport, x.strCountry].filter(Boolean).join(' · ') }));
+  }
+  if (source === 'football-data') {
+    const settings = require('./settings');
+    const apiKey = (settings.getFootballData && settings.getFootballData().apiKey) || (config.footballData && config.footballData.apiKey) || '';
+    if (!apiKey) throw new Error('Configure a football-data.org API key on the admin page first.');
+    const response = await fetch('https://api.football-data.org/v4/competitions', { headers: { 'X-Auth-Token': apiKey }, timeout: 15000 });
+    if (!response.ok) throw new Error('football-data.org returned HTTP ' + response.status);
+    const json = await response.json();
+    const needle = q.toLowerCase();
+    return (json.competitions || []).filter((x) => [x.name, x.code, x.area && x.area.name].some((v) => String(v || '').toLowerCase().includes(needle))).slice(0, 30).map((x) => ({ id: x.code || x.id, name: x.name, description: x.area && x.area.name }));
+  }
+  if (source === 'tmdb') {
+    const apiKey = (config.tmdb && config.tmdb.apiKey) || '';
+    if (!apiKey) throw new Error('Configure TMDB_API_KEY first.');
+    const response = await fetch('https://api.themoviedb.org/3/search/tv?api_key=' + encodeURIComponent(apiKey) + '&query=' + encodeURIComponent(q), { timeout: 15000 });
+    if (!response.ok) throw new Error('TMDB returned HTTP ' + response.status);
+    const json = await response.json();
+    return (json.results || []).slice(0, 30).map((x) => ({ id: x.id, name: x.name, description: [x.first_air_date, x.original_name].filter(Boolean).join(' · ') }));
+  }
+  throw new Error('Unknown source.');
+}
+
+function renderBody(opts) {
+  opts = opts || {};
+  const tab = opts.tab || 'overview';
+  let content;
+  if (tab === 'events') content = eventsPage(opts);
+  else if (tab === 'inbox') content = inboxPage();
+  else if (tab === 'import') content = importPage(opts.preview);
+  else if (tab === 'matching') content = matchingPage(opts.matchResult);
+  else if (tab === 'promotion') content = promotionPage(opts);
+  else content = overview();
+  return '<div class="page-header mb-3"><div class="row align-items-center"><div class="col"><h1 class="page-title">Content Studio</h1><div class="text-secondary mt-1">Curate promotions and events without editing JSON or losing changes on refresh.</div></div></div></div>' + flashHtml(opts.flash) + nav(tab) + content;
+}
+
+module.exports = { renderBody, parseImport, applyImport, suggestMatches, discoverSources };

--- a/lib/catalog.js
+++ b/lib/catalog.js
@@ -29,6 +29,9 @@ function findCatalog(id) {
 // Per-promotion event visibility: lets each promotion drop events it never
 // wants to surface (e.g. UFC's Contender Series).
 function eventVisible(ev) {
+  // Explicitly curated events outrank the automatic promotion filter that
+  // may have sent the source candidate to Content Studio in the first place.
+  if (ev && ev.manual) return true;
   const p = promotions.byPrefix[ev.promotion] || promotions.getByEventId(ev.id);
   if (!p) return true;
   return p.includeEvent ? p.includeEvent(ev, config) : true;

--- a/lib/content-store.js
+++ b/lib/content-store.js
@@ -1,0 +1,222 @@
+// Persistent, refresh-safe editorial layer for Content Studio.
+// Source refreshes continue to own events.json; everything an admin creates,
+// edits or disables is stored separately and composed at read time.
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const config = require('../config');
+const promotions = require('./promotions');
+
+const EMPTY = () => ({
+  version: 1,
+  updatedAt: null,
+  manualEvents: [],
+  eventOverrides: {},
+  disabledEventIds: [],
+  inbox: [],
+});
+
+let cache = null;
+let cacheMtime = 0;
+
+function filePath() {
+  return path.resolve(__dirname, '..', config.contentStudioFile || './data/content-studio.json');
+}
+
+function load() {
+  const fp = filePath();
+  if (!fs.existsSync(fp)) return (cache = EMPTY());
+  const stat = fs.statSync(fp);
+  if (cache && stat.mtimeMs === cacheMtime) return cache;
+  const parsed = JSON.parse(fs.readFileSync(fp, 'utf8'));
+  cache = Object.assign(EMPTY(), parsed || {});
+  cache.manualEvents = Array.isArray(cache.manualEvents) ? cache.manualEvents : [];
+  cache.eventOverrides = cache.eventOverrides && typeof cache.eventOverrides === 'object' ? cache.eventOverrides : {};
+  cache.disabledEventIds = Array.isArray(cache.disabledEventIds) ? cache.disabledEventIds : [];
+  cache.inbox = Array.isArray(cache.inbox) ? cache.inbox : [];
+  cacheMtime = stat.mtimeMs;
+  return cache;
+}
+
+function save(state) {
+  const fp = filePath();
+  fs.mkdirSync(path.dirname(fp), { recursive: true });
+  const next = Object.assign(EMPTY(), state || {}, { updatedAt: new Date().toISOString() });
+  const tmp = fp + '.tmp';
+  fs.writeFileSync(tmp, JSON.stringify(next, null, 2), 'utf8');
+  fs.renameSync(tmp, fp);
+  cache = next;
+  cacheMtime = fs.statSync(fp).mtimeMs;
+  return next;
+}
+
+function slug(value) {
+  return String(value || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 52) || 'event';
+}
+
+function lines(value) {
+  if (Array.isArray(value)) return value.map(String).map((s) => s.trim()).filter(Boolean);
+  return String(value || '').split(/\r?\n|,/).map((s) => s.trim()).filter(Boolean);
+}
+
+function normaliseDate(value) {
+  const v = String(value || '').trim();
+  if (!v) return null;
+  const d = new Date(v.length === 10 ? v + 'T00:00:00Z' : v);
+  if (Number.isNaN(d.getTime())) throw new Error('A valid event date is required.');
+  const iso = d.toISOString().slice(0, 10);
+  if (/^\d{4}-\d{2}-\d{2}$/.test(v) && iso !== v) throw new Error('A valid event date is required.');
+  return iso;
+}
+
+function buildEvent(input, existingId) {
+  const promotionId = String(input.promotion || '').trim();
+  const promotion = promotions.all.find((p) => p.id === promotionId);
+  if (!promotion) throw new Error('Choose a valid promotion.');
+  const name = String(input.name || '').trim();
+  if (!name) throw new Error('Event name is required.');
+  const date = normaliseDate(input.date);
+  const dateLocal = normaliseDate(input.dateLocal || input.date);
+  const id = existingId || promotion.idPrefix + ':manual-' + date + '-' + slug(name) + '-' + crypto.randomBytes(3).toString('hex');
+  const aliases = lines(input.aliases);
+  const searchAliases = lines(input.searchAliases);
+  const kind = String(input.kind || '').trim() || (promotion.classify ? promotion.classify(name) : 'event');
+  return {
+    id,
+    sourceId: id.slice(id.indexOf(':') + 1),
+    promotion: promotion.id,
+    name,
+    kind,
+    date,
+    dateLocal,
+    time: String(input.time || '').trim() || null,
+    venue: String(input.venue || '').trim() || null,
+    city: String(input.city || '').trim() || null,
+    country: String(input.country || '').trim() || null,
+    poster: String(input.poster || '').trim() || (promotion.defaults && promotion.defaults.poster) || null,
+    thumb: String(input.poster || '').trim() || (promotion.defaults && promotion.defaults.poster) || null,
+    fanart: String(input.fanart || '').trim() || (promotion.defaults && promotion.defaults.fanart) || null,
+    banner: String(input.fanart || '').trim() || (promotion.defaults && promotion.defaults.fanart) || null,
+    description: String(input.description || '').trim() || null,
+    shortDescription: String(input.description || '').trim().slice(0, 280) || null,
+    aliases,
+    searchAliases,
+    excludePatterns: lines(input.excludePatterns),
+    posterShape: promotion.posterShape || 'regular',
+    genres: promotion.genres ? promotion.genres({ name, kind, date }) : [promotion.name],
+    source: { type: 'manual' },
+    manual: true,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function upsertManual(input, id) {
+  const state = load();
+  const event = buildEvent(input, id || null);
+  const idx = state.manualEvents.findIndex((e) => e.id === event.id);
+  if (id && idx === -1) throw new Error('Manual event not found.');
+  if (idx >= 0) state.manualEvents[idx] = Object.assign({}, state.manualEvents[idx], event);
+  else state.manualEvents.push(event);
+  state.disabledEventIds = state.disabledEventIds.filter((x) => x !== event.id);
+  save(state);
+  return event;
+}
+
+const EDITABLE = ['name','kind','date','dateLocal','time','venue','city','country','poster','thumb','fanart','banner','description','shortDescription','aliases','searchAliases','excludePatterns'];
+
+function setOverride(id, input) {
+  const state = load();
+  const patch = {};
+  for (const key of EDITABLE) {
+    if (!Object.prototype.hasOwnProperty.call(input, key)) continue;
+    if (['aliases','searchAliases','excludePatterns'].includes(key)) patch[key] = lines(input[key]);
+    else if (key === 'date' || key === 'dateLocal') patch[key] = normaliseDate(input[key]);
+    else patch[key] = String(input[key] || '').trim() || null;
+  }
+  state.eventOverrides[id] = Object.assign({}, state.eventOverrides[id] || {}, patch);
+  save(state);
+  return patch;
+}
+
+function removeOverride(id) {
+  const state = load();
+  delete state.eventOverrides[id];
+  save(state);
+}
+
+function setDisabled(id, disabled) {
+  const state = load();
+  const ids = new Set(state.disabledEventIds);
+  if (disabled) ids.add(id); else ids.delete(id);
+  state.disabledEventIds = Array.from(ids);
+  save(state);
+}
+
+function deleteManual(id) {
+  const state = load();
+  const before = state.manualEvents.length;
+  state.manualEvents = state.manualEvents.filter((e) => e.id !== id);
+  delete state.eventOverrides[id];
+  state.disabledEventIds = state.disabledEventIds.filter((x) => x !== id);
+  if (state.manualEvents.length !== before) save(state);
+  return state.manualEvents.length !== before;
+}
+
+function compose(sourceEvents) {
+  const state = load();
+  const disabled = new Set(state.disabledEventIds);
+  const combined = [].concat(sourceEvents || [], state.manualEvents || []);
+  return combined
+    .filter((e) => e && e.id && !disabled.has(e.id))
+    .map((e) => Object.assign({}, e, state.eventOverrides[e.id] || {}))
+    .sort((a, b) => String(b.date || '').localeCompare(String(a.date || '')));
+}
+
+function inboxKey(candidate, reason) {
+  return crypto.createHash('sha1').update([
+    candidate && candidate.promotion,
+    candidate && (candidate.sourceId || candidate.id),
+    candidate && candidate.name,
+    candidate && candidate.date,
+    reason,
+  ].join('|')).digest('hex').slice(0, 16);
+}
+
+function recordInbox(candidate, reason, details) {
+  if (!candidate || !candidate.name) return null;
+  const state = load();
+  const key = inboxKey(candidate, reason);
+  const idx = state.inbox.findIndex((x) => x.key === key);
+  const previous = idx >= 0 ? state.inbox[idx] : null;
+  if (previous && previous.status === 'ignored') return previous;
+  const item = {
+    key,
+    status: previous ? previous.status : 'pending',
+    reason: reason || 'needs-review',
+    details: String(details || ''),
+    candidate,
+    firstSeenAt: previous ? previous.firstSeenAt : new Date().toISOString(),
+    lastSeenAt: new Date().toISOString(),
+  };
+  if (idx >= 0) state.inbox[idx] = item; else state.inbox.unshift(item);
+  state.inbox = state.inbox.slice(0, 500);
+  save(state);
+  return item;
+}
+
+function updateInbox(key, status, extra) {
+  const state = load();
+  const item = state.inbox.find((x) => x.key === key);
+  if (!item) throw new Error('Inbox item not found.');
+  item.status = status;
+  item.reviewedAt = new Date().toISOString();
+  Object.assign(item, extra || {});
+  save(state);
+  return item;
+}
+
+module.exports = {
+  load, save, filePath, compose, buildEvent, upsertManual, setOverride,
+  removeOverride, setDisabled, deleteManual, recordInbox, updateInbox, lines,
+};

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const config = require('../config');
+const contentStore = require('./content-store');
 
 let cache = null;
 let cacheMtime = 0;
@@ -39,7 +40,7 @@ function saveToDisk(payload) {
 }
 
 function getEvents() {
-  return loadFromDisk().events || [];
+  return contentStore.compose(loadFromDisk().events || []);
 }
 
 function getEvent(id) {

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -98,7 +98,21 @@ function filterCandidates(label, results, log, promo, event) {
   const relevant = [];
   const rejectReasons = {};
   for (const r of noise.results) {
-    const verdict = promo.isRelevantStreamTitle(r.title, event);
+    const blockedByEvent = (event.excludePatterns || []).some((pattern) => {
+      try { return new RegExp(pattern, 'i').test(r.title || ''); } catch (_) { return false; }
+    });
+    if (blockedByEvent) {
+      rejectReasons['event exclusion'] = (rejectReasons['event exclusion'] || 0) + 1;
+      continue;
+    }
+    let verdict = promo.isRelevantStreamTitle(r.title, event);
+    const eventYear = String(event.date || '').slice(0, 4);
+    const titleYears = String(r.title || '').match(/\b20\d{2}\b/g) || [];
+    const wrongExplicitYear = eventYear && titleYears.length > 0 && !titleYears.includes(eventYear);
+    if (!verdict.ok && !wrongExplicitYear && (event.searchAliases || []).some((alias) =>
+      String(alias || '').trim().length >= 4
+      && String(r.title || '').toLowerCase().includes(String(alias).trim().toLowerCase())
+    )) verdict = { ok: true, reason: 'content-studio alias' };
     if (verdict.ok) relevant.push(r);
     else {
       rejectReasons[verdict.reason] = (rejectReasons[verdict.reason] || 0) + 1;
@@ -439,7 +453,7 @@ async function handleStream(params) {
     return { streams: [] };
   }
 
-  const titles = promo.searchTitles(event);
+  const titles = Array.from(new Set([].concat(promo.searchTitles(event) || [], event.searchAliases || []).filter(Boolean)));
   if (titles.length === 0) {
     log('no searchTitles for ' + id + ' (' + event.name + ')');
     return { streams: [] };
@@ -628,7 +642,7 @@ async function searchCandidates(event, log) {
     log('  searchCandidates: no promotion for ' + event.id);
     return [];
   }
-  const titles = promo.searchTitles(event);
+  const titles = Array.from(new Set([].concat(promo.searchTitles(event) || [], event.searchAliases || []).filter(Boolean)));
   if (!titles || titles.length === 0) {
     log('  searchCandidates: no searchTitles for ' + event.id);
     return [];

--- a/lib/tabler-chrome.js
+++ b/lib/tabler-chrome.js
@@ -51,6 +51,8 @@ const ADMIN_SECTIONS = [
     icon: 'M12 21l-8 -4.5v-9l8 -4.5l8 4.5v9l-8 4.5 M12 12l8 -4.5 M12 12v9 M12 12l-8 -4.5' },
   { id: 'promotions',   label: 'Promotions',    href: '/admin/promotions',
     icon: 'M7 4l10 0 M7 20l10 0 M5 4v6a4 4 0 0 0 4 4l6 0a4 4 0 0 0 4 -4v-6 M12 14l0 6' },
+  { id: 'content',      label: 'Content Studio', href: '/admin/content',
+    icon: 'M4 6h16 M4 12h16 M4 18h10 M8 3v6 M16 9v6 M10 15v6' },
   { id: 'backup',       label: 'Backup',        href: '/admin/backup',
     icon: 'M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2 -2v-2 M7 11l5 5l5 -5 M12 4l0 12' },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serioussportsync",
-  "version": "0.42.17",
+  "version": "0.43.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "serioussportsync",
-      "version": "0.42.17",
+      "version": "0.43.0",
       "license": "MIT",
       "dependencies": {
         "bcryptjs": "^2.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name":  "serioussportsync",
-    "version": "0.42.17",
+    "version": "0.43.0",
     "description":  "Self-hosted Stremio/Nuvio sports metadata calendar with optional per-user TorBox, Usenet Ultimate, and Easynews playback pipelines.",
     "main":  "server.js",
     "scripts":  {

--- a/scripts/refresh.js
+++ b/scripts/refresh.js
@@ -6,6 +6,7 @@ const transform = require('../lib/transform');
 const store = require('../lib/store');
 const promotions = require('../lib/promotions');
 const config = require('../config');
+const contentStore = require('../lib/content-store');
 
 let wiki = null;
 try { wiki = require('../lib/sources/wikipedia'); } catch (e) { wiki = null; }
@@ -262,9 +263,19 @@ async function runRefresh(options) {
       if (!norm) continue;
       // Promotion-level filter (e.g. drop WWE weekly TV, UFC Contender Series).
       if (typeof p.includeEvent === 'function' && !p.includeEvent(norm, config)) {
+        contentStore.recordInbox(norm, 'promotion-filter', 'The source returned this event but the promotion filter excluded it.');
         skipped++; continue;
       }
       if (!inScope(norm, p)) { skipped++; continue; }
+      const possibleDuplicate = Array.from(byId.values()).find((existingEvent) =>
+        existingEvent && existingEvent.id !== norm.id
+        && existingEvent.promotion === norm.promotion
+        && String(existingEvent.date || '') === String(norm.date || '')
+        && String(existingEvent.name || '').toLowerCase() === String(norm.name || '').toLowerCase()
+      );
+      if (possibleDuplicate) {
+        contentStore.recordInbox(norm, 'possible-duplicate', 'Looks like ' + possibleDuplicate.id + '. Review and merge if needed.');
+      }
       if (byId.has(norm.id)) updated++;
       else added++;
       byId.set(norm.id, norm);


### PR DESCRIPTION
## What changed

- Adds a Content Studio dashboard for promotion coverage and event management.
- Stores manual events, source overrides, disabled events, and inbox decisions in a refresh-safe editorial layer.
- Adds a missing-event inbox with accept, merge, and ignore actions.
- Adds previewed ICS, CSV, and JSON imports.
- Adds a guided matching assistant connected to event search aliases and exclusions.
- Adds searchable TheSportsDB, football-data.org, and TMDB source discovery with a simplified promotion wizard.
- Documents the workflow and prepares version 0.43.0.

## Why

Adding missing events and promotions previously required editing JSON or application code, and source refreshes could overwrite manual work. This gives administrators a single persistent workflow for curating catalog content.

## Impact

Existing source refresh behavior remains intact. Editorial state is stored separately at `./data/content-studio.json`, which is already covered by the Docker `/app/data` volume.

## Validation

- Syntax-checked every repository JavaScript file.
- Created the Express application and verified route registration.
- Rendered every Content Studio tab.
- Exercised CSV/ICS parsing and persistent manual-event operations.
- Ran `git diff --check`.

Docker Compose validation could not run in the Codex environment because the Docker CLI is unavailable.
