### PR TITLE
Fix TheSportsDB discovery and split seasons

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,7 +51,7 @@ ADDON_TYPE=movie
 # ---- Metadata window (TheSportsDB) -----------------------------------------
 # Free public key is "3"; a Patreon key gives much better rate limits.
 # https://www.thesportsdb.com/free_sports_api
-TSDB_API_KEY=3
+TSDB_API_KEY=123
 # Seasons to pull. 'auto' derives years from the event window below so we don't
 # Optional metadata sources for custom promotions:
 # - football-data.org competition code + API key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.43.1
+
+### TheSportsDB source discovery
+
+- Fixed Content Studio throwing `slice(...).map is not a function` when a
+  TheSportsDB name search returned its string error payload.
+- Replaced the unsupported v1 league-name query with the free API's exact
+  league-name team lookup and deduplicated its league results.
+- Added direct numeric league-ID lookup and clearer free-API search guidance.
+- Updated the default public v1 API key from the legacy `3` key to TheSportsDB's
+  documented `123` key, raising season results from 5 to the free limit of 15.
+- Existing deployments that still set `TSDB_API_KEY=3` are migrated to `123`
+  automatically; premium/user keys remain untouched.
+- Added automatic split-season detection so NBA/EPL-style leagues query
+  `2025-2026` and `2026-2027` rather than empty calendar-year seasons.
+- Added refresh logging when a response reaches the free 15-event schedule cap.
+
 ## 0.43.0
 
 ### Content Studio

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Monkfish1337/Serioussportsync/releases"><img src="https://img.shields.io/badge/version-0.43.0-blue.svg" alt="Version 0.43.0"></a>
+  <a href="https://github.com/Monkfish1337/Serioussportsync/releases"><img src="https://img.shields.io/badge/version-0.43.1-blue.svg" alt="Version 0.43.1"></a>
   <a href="https://github.com/Monkfish1337/Serioussportsync/actions/workflows/ci.yml"><img src="https://github.com/Monkfish1337/Serioussportsync/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://github.com/Monkfish1337/Serioussportsync/pkgs/container/serioussportsync"><img src="https://img.shields.io/badge/GHCR-container-2496ED?logo=docker&logoColor=white" alt="Container image"></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="MIT license"></a>

--- a/config.js
+++ b/config.js
@@ -13,6 +13,10 @@ const seasonsEnv = (process.env.TSDB_SEASONS || 'auto').trim();
 const explicitSeasons = (seasonsEnv === '' || seasonsEnv.toLowerCase() === 'auto')
   ? null
   : seasonsEnv.split(',').map((s) => s.trim()).filter(Boolean);
+// Migrate existing Compose environments that copied the legacy public key.
+// A real user/premium key is preserved verbatim.
+const tsdbKeyEnv = String(process.env.TSDB_API_KEY || '123').trim();
+const tsdbApiKey = tsdbKeyEnv === '3' ? '123' : tsdbKeyEnv;
 
 module.exports = {
   port: parseInt(process.env.PORT, 10) || 7000,
@@ -32,7 +36,9 @@ module.exports = {
   background: 'https://upload.wikimedia.org/wikipedia/commons/7/7a/UFC-Octagon-USMCPhoto.jpg',
 
   tsdb: {
-    apiKey: process.env.TSDB_API_KEY || '3',
+    // TheSportsDB's current documented free v1 key. Older releases used the
+    // legacy test key `3`, whose schedule endpoints have lower result caps.
+    apiKey: tsdbApiKey,
     leagueId: '4443',
     requestDelayMs: 3000,
     // null = derive from event window at refresh time. Set TSDB_SEASONS to a

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       # discoverable without opening .env.example.
       PORT: "7000"
       ADDON_TYPE: "${ADDON_TYPE:-movie}"
-      TSDB_API_KEY: "${TSDB_API_KEY:-3}"
+      TSDB_API_KEY: "${TSDB_API_KEY:-123}"
       TSDB_SEASONS: "${TSDB_SEASONS:-auto}"
       REFRESH_INTERVAL_HOURS: "${REFRESH_INTERVAL_HOURS:-6}"
       # Content discovery. The companion can combine Prowlarr/Zilean/etc;

--- a/lib/admin-content-studio.js
+++ b/lib/admin-content-studio.js
@@ -194,7 +194,10 @@ function promotionPage(opts) {
   opts = opts || {};
   const source = opts.source || 'tsdb';
   const discovered = (opts.discovery || []).map((item) => '<tr><td><strong>' + e(item.name) + '</strong><br><small class="text-secondary">' + e(item.description) + '</small></td><td class="text-mono">' + e(item.id) + '</td><td><a class="btn btn-sm btn-primary" href="/admin/content?tab=promotion&source=' + encodeURIComponent(source) + '&sourceId=' + encodeURIComponent(item.id) + '&name=' + encodeURIComponent(item.name) + '">Use this source</a></td></tr>').join('');
-  const discovery = '<div class="card mb-3"><div class="card-header"><h3 class="card-title">Find a source</h3></div><div class="card-body"><form method="GET" action="/admin/content"><input type="hidden" name="tab" value="promotion"><input type="hidden" name="discover" value="1"><div class="row g-2"><div class="col-md-3"><select class="form-select" name="source"><option value="tsdb"' + selected(source,'tsdb') + '>TheSportsDB</option><option value="football-data"' + selected(source,'football-data') + '>football-data.org</option><option value="tmdb"' + selected(source,'tmdb') + '>TMDB TV show</option></select></div><div class="col-md-7"><input class="form-control" name="query" value="' + e(opts.discoveryQuery) + '" placeholder="Search by league, competition, or show name"></div><div class="col-md-2"><button class="btn btn-outline-primary w-100">Search</button></div></div></form></div>' + (opts.discovery ? '<div class="table-responsive"><table class="table"><tbody>' + (discovered || '<tr><td class="text-secondary">No matching sources found.</td></tr>') + '</tbody></table></div>' : '') + '</div>';
+  const noResults = source === 'tsdb'
+    ? 'No match found. The free TheSportsDB API requires an exact league name (for example NBA) or a numeric league ID.'
+    : 'No matching sources found.';
+  const discovery = '<div class="card mb-3"><div class="card-header"><h3 class="card-title">Find a source</h3></div><div class="card-body"><form method="GET" action="/admin/content"><input type="hidden" name="tab" value="promotion"><input type="hidden" name="discover" value="1"><div class="row g-2"><div class="col-md-3"><select class="form-select" name="source"><option value="tsdb"' + selected(source,'tsdb') + '>TheSportsDB</option><option value="football-data"' + selected(source,'football-data') + '>football-data.org</option><option value="tmdb"' + selected(source,'tmdb') + '>TMDB TV show</option></select></div><div class="col-md-7"><input class="form-control" name="query" value="' + e(opts.discoveryQuery) + '" placeholder="Exact league name, source ID, competition, or show name"></div><div class="col-md-2"><button class="btn btn-outline-primary w-100">Search</button></div></div></form></div>' + (opts.discovery ? '<div class="table-responsive"><table class="table"><tbody>' + (discovered || '<tr><td class="text-secondary">' + e(noResults) + '</td></tr>') + '</tbody></table></div>' : '') + '</div>';
   return '<h2>Add a promotion</h2><p class="text-secondary">Find the source by name, preview its ID, then create the promotion with practical matching defaults.</p>' + discovery + '<div class="card"><div class="card-body"><form method="POST" action="/admin/content/promotions/create"><div class="row g-3"><div class="col-md-4"><label class="form-label">Name</label><input class="form-control" required name="name" value="' + e(opts.name) + '" placeholder="National Football League"></div><div class="col-md-3"><label class="form-label">Short ID</label><input class="form-control" required pattern="[a-z0-9_-]{2,30}" name="id" placeholder="nfl"></div><div class="col-md-3"><label class="form-label">Source</label><select class="form-select" name="source" id="quickSource"><option value="tsdb"' + selected(source,'tsdb') + '>TheSportsDB</option><option value="football-data"' + selected(source,'football-data') + '>football-data.org</option><option value="tmdb"' + selected(source,'tmdb') + '>TMDB TV show</option></select></div><div class="col-md-2"><label class="form-label">Source ID</label><input class="form-control" required name="sourceId" value="' + e(opts.sourceId) + '" placeholder="4391"></div><div class="col-md-6"><label class="form-label">Poster URL (optional)</label><input class="form-control" type="url" name="poster"></div><div class="col-md-6"><label class="form-label">Background URL (optional)</label><input class="form-control" type="url" name="fanart"></div></div><details class="mt-3"><summary class="text-secondary">Advanced matching defaults</summary><div class="row g-3 mt-1"><div class="col-md-6"><label class="form-label">Search templates</label><textarea class="form-control" name="searchTitleTemplates" rows="3" placeholder="{name}\n{name} {year}"></textarea></div><div class="col-md-6"><label class="form-label">Relevance keywords</label><input class="form-control" name="relevanceKeywords" placeholder="nfl, football"></div></div></details><button class="btn btn-primary mt-3">Create promotion</button> <a class="btn btn-link" href="/admin/promotions">Open full advanced editor</a></form></div></div>';
 }
 
@@ -202,12 +205,35 @@ async function discoverSources(source, query) {
   const q = String(query || '').trim();
   if (q.length < 2) throw new Error('Enter at least two characters to search.');
   if (source === 'tsdb') {
-    const key = (config.tsdb && config.tsdb.apiKey) || '3';
-    const url = 'https://www.thesportsdb.com/api/v1/json/' + encodeURIComponent(key) + '/search_all_leagues.php?l=' + encodeURIComponent(q);
+    const key = (config.tsdb && config.tsdb.apiKey) || '123';
+    // The v1 `search_all_leagues.php` endpoint only filters by country/sport;
+    // passing `l=NBA` returns `{ countries: "Invalid name passed" }`. The free
+    // v1 API can still resolve an exact league name via its team listing,
+    // whose rows carry idLeague/strLeague. Numeric input uses the direct
+    // league lookup. Premium v2 has true free-text league search, but requiring
+    // that here would make the default public v1 key unusable.
+    const numeric = /^\d+$/.test(q);
+    const endpoint = numeric
+      ? '/lookupleague.php?id=' + encodeURIComponent(q)
+      : '/search_all_teams.php?l=' + encodeURIComponent(q);
+    const url = 'https://www.thesportsdb.com/api/v1/json/' + encodeURIComponent(key) + endpoint;
     const response = await fetch(url, { headers: { 'User-Agent': 'serioussportsync/content-studio' }, timeout: 15000 });
     if (!response.ok) throw new Error('TheSportsDB returned HTTP ' + response.status);
     const json = await response.json();
-    return (json.countries || []).slice(0, 30).map((x) => ({ id: x.idLeague, name: x.strLeague, description: [x.strSport, x.strCountry].filter(Boolean).join(' · ') }));
+    const rows = numeric
+      ? (Array.isArray(json.leagues) ? json.leagues : [])
+      : (Array.isArray(json.teams) ? json.teams : []);
+    const found = new Map();
+    for (const row of rows) {
+      const id = String(row && row.idLeague || '').trim();
+      if (!id || found.has(id)) continue;
+      found.set(id, {
+        id,
+        name: row.strLeague || q,
+        description: [row.strSport, row.strCountry].filter(Boolean).join(' · '),
+      });
+    }
+    return Array.from(found.values()).slice(0, 30);
   }
   if (source === 'football-data') {
     const settings = require('./settings');

--- a/lib/admin-promotions.js
+++ b/lib/admin-promotions.js
@@ -509,7 +509,7 @@ async function validateLeagueId(leagueId) {
   const id = String(leagueId || '').trim();
   if (!/^\d+$/.test(id)) return { ok: false, error: 'leagueId must be numeric' };
 
-  const key = (config && config.tsdb && config.tsdb.apiKey) || '3';   // '3' is TSDB's free public key
+  const key = (config && config.tsdb && config.tsdb.apiKey) || '123';
   const lookupUrl = 'https://www.thesportsdb.com/api/v1/json/' + encodeURIComponent(key)
                   + '/lookupleague.php?id=' + encodeURIComponent(id);
 
@@ -524,8 +524,9 @@ async function validateLeagueId(leagueId) {
   const league = leagueJson && leagueJson.leagues && leagueJson.leagues[0];
   if (!league) return { ok: false, error: 'TSDB returned no league for id ' + id };
 
-  // Pull recent events from current year season to confirm the league has data.
-  const currentYear = new Date().getUTCFullYear();
+  // Use the league's own season label. Football/basketball leagues use split
+  // seasons such as 2026-2027; querying the calendar year silently returns 0.
+  const currentYear = league.strCurrentSeason || String(new Date().getUTCFullYear());
   const seasonUrl = 'https://www.thesportsdb.com/api/v1/json/' + encodeURIComponent(key)
                   + '/eventsseason.php?id=' + encodeURIComponent(id)
                   + '&s=' + currentYear;

--- a/lib/sources/thesportsdb.js
+++ b/lib/sources/thesportsdb.js
@@ -40,6 +40,30 @@ async function getJson(url, options) {
 // this client. Falls back to config.tsdb.leagueId for backward compat.
 function lid(leagueId) { return leagueId || config.tsdb.leagueId; }
 
+async function fetchLeague(leagueId, log) {
+  const url = BASE(config.tsdb.apiKey) + '/lookupleague.php?id=' + lid(leagueId);
+  const leagues = (await getJson(url, { log })).leagues;
+  return Array.isArray(leagues) ? (leagues[0] || null) : null;
+}
+
+// Convert the calendar years used by SSS's global event window into the
+// source's season convention. Combat/motorsport leagues normally expose
+// `2026`; NBA/EPL-style leagues expose `2026-2027`.
+function resolveSeasonIds(requested, currentSeason) {
+  const input = (requested || []).map((s) => String(s || '').trim()).filter(Boolean);
+  if (!/^\d{4}-\d{4}$/.test(String(currentSeason || ''))) return input;
+  // Explicit split seasons are already authoritative.
+  if (input.some((s) => /^\d{4}-\d{4}$/.test(s))) return Array.from(new Set(input));
+  const out = new Set();
+  for (const season of input) {
+    if (!/^\d{4}$/.test(season)) { out.add(season); continue; }
+    const year = Number(season);
+    out.add(String(year - 1) + '-' + String(year));
+    out.add(String(year) + '-' + String(year + 1));
+  }
+  return Array.from(out).sort();
+}
+
 async function fetchUpcoming(leagueId, log) {
   const url = BASE(config.tsdb.apiKey) + '/eventsnextleague.php?id=' + lid(leagueId);
   return (await getJson(url, { log })).events || [];
@@ -87,9 +111,17 @@ async function fetchSeasonAllRounds(leagueId, season, log) {
 async function fetchAll(opts) {
   opts = opts || {};
   const leagueId = opts.leagueId || config.tsdb.leagueId;
-  const seasons = opts.seasons || config.tsdb.seasons;
+  const requestedSeasons = opts.seasons || config.tsdb.seasons || [];
   const log = opts.log || (() => {});
   const dedup = new Map();
+
+  let league = null;
+  try { league = await fetchLeague(leagueId, log); }
+  catch (err) { log('  league lookup failed; using requested seasons unchanged: ' + err.message); }
+  const seasons = resolveSeasonIds(requestedSeasons, league && league.strCurrentSeason);
+  if (seasons.join(',') !== requestedSeasons.join(',')) {
+    log('  split-season league (' + league.strCurrentSeason + '): resolved seasons to ' + seasons.join(', '));
+  }
 
   log('-> upcoming (eventsnextleague)');
   try { for (const e of await fetchUpcoming(leagueId, log)) if (e.idEvent) dedup.set(e.idEvent, e); }
@@ -103,8 +135,15 @@ async function fetchAll(opts) {
 
   for (const season of seasons) {
     log('-> season ' + season + ' bulk');
+    let bulkCount = 0;
     try {
-      for (const e of await fetchSeasonBulk(leagueId, season, log)) if (e.idEvent) dedup.set(e.idEvent, e);
+      const bulk = await fetchSeasonBulk(leagueId, season, log);
+      bulkCount = bulk.length;
+      for (const e of bulk) if (e.idEvent) dedup.set(e.idEvent, e);
+      log('  season ' + season + ' bulk returned ' + bulkCount + ' event(s)');
+      if (bulkCount === 15 && String(config.tsdb.apiKey) === '123') {
+        log('  season response reached the TheSportsDB free-key limit (15); use a premium TSDB_API_KEY for complete league schedules');
+      }
     } catch (err) { log('  bulk season ' + season + ' failed: ' + err.message); }
     await delay(config.tsdb.requestDelayMs);
 
@@ -117,6 +156,6 @@ async function fetchAll(opts) {
 }
 
 module.exports = {
-  fetchUpcoming, fetchRecent, fetchSeasonBulk, fetchRound,
-  fetchSeasonAllRounds, fetchAll,
+  fetchLeague, fetchUpcoming, fetchRecent, fetchSeasonBulk, fetchRound,
+  fetchSeasonAllRounds, fetchAll, resolveSeasonIds,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serioussportsync",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "serioussportsync",
-      "version": "0.43.0",
+      "version": "0.43.1",
       "license": "MIT",
       "dependencies": {
         "bcryptjs": "^2.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name":  "serioussportsync",
-    "version": "0.43.0",
+    "version": "0.43.1",
     "description":  "Self-hosted Stremio/Nuvio sports metadata calendar with optional per-user TorBox, Usenet Ultimate, and Easynews playback pipelines.",
     "main":  "server.js",
     "scripts":  {


### PR DESCRIPTION
## What changed

- fixes Content Studio TheSportsDB name searches by using the supported free-v1 team listing and direct numeric league lookup
- normalizes malformed/string API responses instead of throwing in the UI
- updates the default TheSportsDB free key from legacy `3` to documented key `123`
- automatically migrates existing `TSDB_API_KEY=3` deployments while preserving user/premium keys
- detects split-season leagues such as NBA and EPL and resolves calendar windows to season IDs such as `2025-2026`
- validates promotions against each league's real current season
- logs when the free 15-event season cap is reached
- prepares release 0.43.1

## Why

TheSportsDB v1 does not support league-name searches through `search_all_leagues.php?l=...`; it returns a string error that the new Content Studio treated as an array. NBA/EPL refreshes also queried calendar years even though their source seasons span two years, leaving only the one-item recent/upcoming responses.

## Impact

NBA and EPL promotions now query their real split seasons. Free-key installs receive up to TheSportsDB's documented 15-event season limit instead of the legacy key's lower cap. Complete league schedules still require a premium TheSportsDB key.

## Validation

- syntax-checked every repository JavaScript file
- loaded the Express application and affected modules
- verified `TSDB_API_KEY=3` migrates to `123`
- verified `2025, 2026` resolves to `2024-2025, 2025-2026, 2026-2027`
- live API checks resolved NBA to league `4387`, EPL to `4328`, and returned 15 NBA events for `2026-2027`
- ran `git diff --check`
