### PR TITLE
Release v0.43.2: guided promotions and matchup fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.43.2
+
+### Guided promotion setup
+
+- Reworked Content Studio's promotion creator into a two-step source wizard.
+- Automatically infers the short ID, safe search templates, recognition terms,
+  date matching, and known football team/league alias presets.
+- Previews real recent/upcoming source events and imports available source
+  artwork before creation, making an incorrect source easy to spot.
+- Starts the promotion's first event import automatically after creation.
+
+### Matchup stream matching
+
+- Added reversed and `@` search variants for generic matchup promotions such
+  as NBA, NHL, and MLB, including exact ISO/DMY date variants.
+- Treats both canonical team names plus an exact fixture date as authoritative,
+  regardless of home/away order or overly narrow promotion keywords.
+- Added full `YYYY-YYYY` season-token support alongside `YYYY-YY`.
+- Fixed completed/skipped pipelines emitting phantom timeout logs later because
+  their timeout timers were not cancelled.
+- Stream requests now use the composed Content Studio event store, so saved
+  event aliases and overrides affect playback searches.
+
 ## 0.43.1
 
 ### TheSportsDB source discovery

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Monkfish1337/Serioussportsync/releases"><img src="https://img.shields.io/badge/version-0.43.1-blue.svg" alt="Version 0.43.1"></a>
+  <a href="https://github.com/Monkfish1337/Serioussportsync/releases"><img src="https://img.shields.io/badge/version-0.43.2-blue.svg" alt="Version 0.43.2"></a>
   <a href="https://github.com/Monkfish1337/Serioussportsync/actions/workflows/ci.yml"><img src="https://github.com/Monkfish1337/Serioussportsync/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://github.com/Monkfish1337/Serioussportsync/pkgs/container/serioussportsync"><img src="https://img.shields.io/badge/GHCR-container-2496ED?logo=docker&logoColor=white" alt="Container image"></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="MIT license"></a>
@@ -145,7 +145,8 @@ JSON or application code.
 - **Services:** configure direct Prowlarr, the companion scraper, and Newznab.
 - **Users:** create invites and manage shared deployments.
 - **Match editor:** add aliases or noise rules and test a release before saving.
-- **Promotions creator:** add TSDB, football-data.org, or TMDB-backed sports.
+- **Guided promotions creator:** find a TSDB, football-data.org, or TMDB source,
+  preview real events, auto-configure matching, then create and import in one step.
 - **Content Studio:** search metadata sources, review promotion coverage, add or
   edit events, and disable unwanted entries without losing changes on refresh.
 - **Missing event inbox:** accept, merge, or ignore source events rejected by

--- a/addon.js
+++ b/addon.js
@@ -1000,11 +1000,16 @@ function createApp() {
       source: String(req.query.source || 'tsdb'),
       sourceId: String(req.query.sourceId || ''),
       name: String(req.query.name || ''),
+      guided: req.query.guided === '1',
       discoveryQuery: String(req.query.query || ''),
     };
     if (view.tab === 'promotion' && req.query.discover === '1') {
       try { view.discovery = await contentStudio.discoverSources(view.source, view.discoveryQuery); }
       catch (err) { view.flash = 'Source search failed: ' + err.message; view.discovery = []; }
+    }
+    if (view.tab === 'promotion' && view.guided && view.sourceId) {
+      try { view.sourcePreview = await contentStudio.inspectSource(view.source, view.sourceId); }
+      catch (err) { view.flash = 'Source preview warning: ' + err.message; view.sourcePreview = { samples: [] }; }
     }
     const body = contentStudio.renderBody(view);
     res.send(tablerChrome.tablerPage('Content Studio', body, { user: req.user, currentSection: 'content' }));
@@ -1123,13 +1128,21 @@ function createApp() {
       const body = Object.assign({}, req.body || {});
       const name = String(body.name || '').trim();
       const source = String(body.source || 'tsdb');
-      body.searchTitleTemplates = String(body.searchTitleTemplates || '').trim() || '{name}\n{name} {year}';
-      body.relevanceKeywords = String(body.relevanceKeywords || '').trim() || [body.id, name].filter(Boolean).join(', ');
+      const inferred = contentStudio.inferPromotionSetup(name, source);
+      body.id = String(body.id || '').trim() || inferred.id;
+      body.searchTitleTemplates = String(body.searchTitleTemplates || '').trim() || inferred.searchTitleTemplates.join('\n');
+      body.relevanceKeywords = String(body.relevanceKeywords || '').trim() || inferred.relevanceKeywords.join(', ');
+      body.teamAliasPreset = String(body.teamAliasPreset || '').trim() || inferred.teamAliasPreset;
+      body.leagueAliases = String(body.leagueAliases || '').trim() || inferred.leagueAliases.join(', ');
+      if (body.requireDateInTitle === undefined) body.requireDateInTitle = inferred.requireDateInTitle ? '1' : '0';
       if (source === 'tsdb') body.leagueId = body.sourceId;
       else if (source === 'football-data') body.competitionId = body.sourceId;
       else if (source === 'tmdb') body.tvId = body.sourceId;
       const spec = adminPromotions.saveFromForm(body);
-      res.redirect(contentRedirect('overview', 'Created ' + spec.name + '. Use Refresh on its card to fetch events.'));
+      runEventsRefresh({ promotionId: spec.id })
+        .then((result) => console.log('[content-wizard] initial import "' + spec.id + '" complete: ' + JSON.stringify(result)))
+        .catch((err) => console.error('[content-wizard] initial import "' + spec.id + '" failed: ' + err.message));
+      res.redirect(contentRedirect('overview', 'Created ' + spec.name + '. Its first event import has started automatically.'));
     } catch (err) { res.redirect(contentRedirect('promotion', 'Create failed: ' + err.message)); }
   });
 

--- a/lib/admin-content-studio.js
+++ b/lib/admin-content-studio.js
@@ -105,6 +105,48 @@ function suggestMatches(positiveText, negativeText) {
   return { aliases: Array.from(new Set(aliases)).slice(0, 6), keywords: common.slice(0, 10), excludePatterns: negativeDistinct.map((x) => '\\b' + x.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\b') };
 }
 
+const PROMOTION_ID_STOP = new Set(['the', 'of', 'and', 'for']);
+function promotionSlug(name) {
+  const words = String(name || '').toLowerCase().match(/[a-z0-9]+/g) || [];
+  const useful = words.filter((word) => !PROMOTION_ID_STOP.has(word));
+  const acronym = useful.map((word) => word[0]).join('');
+  if (acronym.length >= 2 && acronym.length <= 6 && useful.length >= 2) return acronym;
+  return useful.join('-').slice(0, 30) || 'sport';
+}
+
+function inferPromotionSetup(name, source, samples) {
+  const cleanName = String(name || '').trim();
+  const lc = cleanName.toLowerCase();
+  const id = promotionSlug(cleanName);
+  const acronym = (cleanName.match(/\b[A-Z0-9]{2,6}\b/g) || [])[0]
+    || cleanName.split(/\s+/).filter((word) => word && !PROMOTION_ID_STOP.has(word.toLowerCase())).map((word) => word[0]).join('').toUpperCase();
+  let teamAliasPreset = '';
+  if (/english premier league|\bpremier league\b|\bepl\b/.test(lc)) teamAliasPreset = 'epl';
+  else if (/^(efl |english football league )?championship$/.test(lc)) teamAliasPreset = 'championship';
+  else if (/league one|league 1/.test(lc)) teamAliasPreset = 'league-one';
+  else if (/champions league|\bucl\b/.test(lc)) teamAliasPreset = 'ucl';
+
+  const matchupSamples = (samples || []).filter((item) => /\s(?:vs?\.?|@)\s/i.test(String(item && item.name || ''))).length;
+  const matchupSource = source === 'football-data' || matchupSamples > 0;
+  const episodeSource = source === 'tmdb';
+  const templates = episodeSource
+    ? ['{name} {date}', '{name} {year}', '{name}']
+    : ['{name}', '{name} {year}', '{name} {date}'];
+  const keywords = Array.from(new Set([id, acronym, cleanName]
+    .map((value) => String(value || '').toLowerCase().trim()).filter((value) => value.length >= 3)));
+  const aliasPresets = require('./team-alias-presets');
+  const leagueAliases = teamAliasPreset ? aliasPresets.getLeagueAliasDefaults(teamAliasPreset) : [];
+  return {
+    id,
+    searchTitleTemplates: templates,
+    relevanceKeywords: keywords,
+    teamAliasPreset,
+    leagueAliases,
+    requireDateInTitle: matchupSource || !!teamAliasPreset,
+    mode: episodeSource ? 'dated episodes' : matchupSource ? 'team matchups' : 'automatic event detection',
+  };
+}
+
 function promotionOptions(value) {
   return promotions.all.map((p) => '<option value="' + e(p.id) + '"' + selected(p.id, value) + '>' + e(p.name) + '</option>').join('');
 }
@@ -193,12 +235,66 @@ function matchingPage(result) {
 function promotionPage(opts) {
   opts = opts || {};
   const source = opts.source || 'tsdb';
-  const discovered = (opts.discovery || []).map((item) => '<tr><td><strong>' + e(item.name) + '</strong><br><small class="text-secondary">' + e(item.description) + '</small></td><td class="text-mono">' + e(item.id) + '</td><td><a class="btn btn-sm btn-primary" href="/admin/content?tab=promotion&source=' + encodeURIComponent(source) + '&sourceId=' + encodeURIComponent(item.id) + '&name=' + encodeURIComponent(item.name) + '">Use this source</a></td></tr>').join('');
+  const discovered = (opts.discovery || []).map((item) => '<tr><td><strong>' + e(item.name) + '</strong><br><small class="text-secondary">' + e(item.description) + '</small></td><td class="text-mono">' + e(item.id) + '</td><td><a class="btn btn-sm btn-primary" href="/admin/content?tab=promotion&source=' + encodeURIComponent(source) + '&sourceId=' + encodeURIComponent(item.id) + '&name=' + encodeURIComponent(item.name) + '&guided=1">Select</a></td></tr>').join('');
   const noResults = source === 'tsdb'
     ? 'No match found. The free TheSportsDB API requires an exact league name (for example NBA) or a numeric league ID.'
     : 'No matching sources found.';
-  const discovery = '<div class="card mb-3"><div class="card-header"><h3 class="card-title">Find a source</h3></div><div class="card-body"><form method="GET" action="/admin/content"><input type="hidden" name="tab" value="promotion"><input type="hidden" name="discover" value="1"><div class="row g-2"><div class="col-md-3"><select class="form-select" name="source"><option value="tsdb"' + selected(source,'tsdb') + '>TheSportsDB</option><option value="football-data"' + selected(source,'football-data') + '>football-data.org</option><option value="tmdb"' + selected(source,'tmdb') + '>TMDB TV show</option></select></div><div class="col-md-7"><input class="form-control" name="query" value="' + e(opts.discoveryQuery) + '" placeholder="Exact league name, source ID, competition, or show name"></div><div class="col-md-2"><button class="btn btn-outline-primary w-100">Search</button></div></div></form></div>' + (opts.discovery ? '<div class="table-responsive"><table class="table"><tbody>' + (discovered || '<tr><td class="text-secondary">' + e(noResults) + '</td></tr>') + '</tbody></table></div>' : '') + '</div>';
-  return '<h2>Add a promotion</h2><p class="text-secondary">Find the source by name, preview its ID, then create the promotion with practical matching defaults.</p>' + discovery + '<div class="card"><div class="card-body"><form method="POST" action="/admin/content/promotions/create"><div class="row g-3"><div class="col-md-4"><label class="form-label">Name</label><input class="form-control" required name="name" value="' + e(opts.name) + '" placeholder="National Football League"></div><div class="col-md-3"><label class="form-label">Short ID</label><input class="form-control" required pattern="[a-z0-9_-]{2,30}" name="id" placeholder="nfl"></div><div class="col-md-3"><label class="form-label">Source</label><select class="form-select" name="source" id="quickSource"><option value="tsdb"' + selected(source,'tsdb') + '>TheSportsDB</option><option value="football-data"' + selected(source,'football-data') + '>football-data.org</option><option value="tmdb"' + selected(source,'tmdb') + '>TMDB TV show</option></select></div><div class="col-md-2"><label class="form-label">Source ID</label><input class="form-control" required name="sourceId" value="' + e(opts.sourceId) + '" placeholder="4391"></div><div class="col-md-6"><label class="form-label">Poster URL (optional)</label><input class="form-control" type="url" name="poster"></div><div class="col-md-6"><label class="form-label">Background URL (optional)</label><input class="form-control" type="url" name="fanart"></div></div><details class="mt-3"><summary class="text-secondary">Advanced matching defaults</summary><div class="row g-3 mt-1"><div class="col-md-6"><label class="form-label">Search templates</label><textarea class="form-control" name="searchTitleTemplates" rows="3" placeholder="{name}\n{name} {year}"></textarea></div><div class="col-md-6"><label class="form-label">Relevance keywords</label><input class="form-control" name="relevanceKeywords" placeholder="nfl, football"></div></div></details><button class="btn btn-primary mt-3">Create promotion</button> <a class="btn btn-link" href="/admin/promotions">Open full advanced editor</a></form></div></div>';
+  const preview = opts.sourcePreview || null;
+  const setup = inferPromotionSetup(opts.name, source, preview && preview.samples);
+  const ready = !!(opts.sourceId && opts.name);
+  const sampleRows = preview && preview.samples && preview.samples.length
+    ? preview.samples.slice(0, 5).map((item) => '<tr><td>' + e(item.name) + '</td><td class="text-nowrap text-secondary">' + e(item.date) + '</td></tr>').join('')
+    : '';
+  const samplePreview = ready ? '<div class="card mb-3"><div class="card-header"><h3 class="card-title">Source preview</h3><span class="badge ' + (sampleRows ? 'bg-green-lt' : 'bg-yellow-lt') + ' ms-auto">' + (sampleRows ? 'events found' : 'no sample events') + '</span></div>' + (sampleRows ? '<div class="table-responsive"><table class="table table-sm table-vcenter mb-0"><tbody>' + sampleRows + '</tbody></table></div>' : '<div class="card-body text-secondary">The source is valid, but its lightweight recent/upcoming feed did not return sample events. The full import will still check configured seasons.</div>') + '</div>' : '';
+  const automaticSummary = ready ? '<div class="alert alert-success"><div class="d-flex align-items-center"><div><strong>Source connected. Automatic setup is ready.</strong><div class="text-secondary mt-1">Detected mode: ' + e(setup.mode) + ' · ID: <code>' + e(setup.id) + '</code> · ' + (setup.teamAliasPreset ? 'built-in ' + e(setup.teamAliasPreset.toUpperCase()) + ' team aliases · ' : '') + 'event dates and both team orders will be used automatically.</div></div></div></div>' : '<div class="alert alert-info">Start by searching for the league, promotion, or sports show. Selecting a result fills in the technical settings for you.</div>';
+  const discovery = '<div class="card mb-3"><div class="card-header"><h3 class="card-title">1. Find the content source</h3></div><div class="card-body"><form method="GET" action="/admin/content"><input type="hidden" name="tab" value="promotion"><input type="hidden" name="discover" value="1"><div class="row g-2"><div class="col-md-3"><select class="form-select" name="source"><option value="tsdb"' + selected(source,'tsdb') + '>TheSportsDB</option><option value="football-data"' + selected(source,'football-data') + '>football-data.org</option><option value="tmdb"' + selected(source,'tmdb') + '>TMDB TV show</option></select></div><div class="col-md-7"><input class="form-control" name="query" value="' + e(opts.discoveryQuery) + '" placeholder="League, promotion, competition, or show name"></div><div class="col-md-2"><button class="btn btn-outline-primary w-100">Search</button></div></div></form></div>' + (opts.discovery ? '<div class="table-responsive"><table class="table"><tbody>' + (discovered || '<tr><td class="text-secondary">' + e(noResults) + '</td></tr>') + '</tbody></table></div>' : '') + '</div>';
+  return '<h2>Add a promotion</h2><p class="text-secondary">Choose a metadata source; SeriousSportSync configures matching and imports the first events automatically.</p>' + automaticSummary + discovery + samplePreview + '<div class="card"><div class="card-header"><h3 class="card-title">2. Review and create</h3></div><div class="card-body"><form method="POST" action="/admin/content/promotions/create"><div class="row g-3"><div class="col-md-5"><label class="form-label">Display name</label><input class="form-control" required name="name" value="' + e(opts.name) + '" placeholder="Select a source above"></div><div class="col-md-3"><label class="form-label">Short ID</label><input class="form-control" required pattern="[a-z0-9_-]{2,30}" name="id" value="' + e(ready ? setup.id : '') + '" placeholder="created automatically"></div><div class="col-md-2"><label class="form-label">Source</label><input class="form-control" value="' + e(source === 'tsdb' ? 'TheSportsDB' : source === 'football-data' ? 'football-data.org' : 'TMDB') + '" readonly><input type="hidden" name="source" value="' + e(source) + '"></div><div class="col-md-2"><label class="form-label">Source ID</label><input class="form-control" required readonly name="sourceId" value="' + e(opts.sourceId) + '" placeholder="select above"></div><div class="col-md-6"><label class="form-label">Poster URL <span class="text-secondary">optional</span></label><input class="form-control" type="url" name="poster" value="' + e(preview && preview.poster) + '"></div><div class="col-md-6"><label class="form-label">Background URL <span class="text-secondary">optional</span></label><input class="form-control" type="url" name="fanart" value="' + e(preview && preview.fanart) + '"></div></div><input type="hidden" name="teamAliasPreset" value="' + e(setup.teamAliasPreset) + '"><input type="hidden" name="leagueAliases" value="' + e(setup.leagueAliases.join(', ')) + '"><input type="hidden" name="requireDateInTitle" value="' + (setup.requireDateInTitle ? '1' : '0') + '"><details class="mt-3"><summary class="text-secondary">Review automatic matching (optional)</summary><div class="row g-3 mt-1"><div class="col-md-6"><label class="form-label">Search patterns</label><textarea class="form-control" name="searchTitleTemplates" rows="3">' + e(setup.searchTitleTemplates.join('\n')) + '</textarea></div><div class="col-md-6"><label class="form-label">Recognition terms</label><input class="form-control" name="relevanceKeywords" value="' + e(setup.relevanceKeywords.join(', ')) + '"><small class="text-secondary">Team names plus the exact event date take priority for matchup events.</small></div></div></details><button class="btn btn-primary mt-3"' + (ready ? '' : ' disabled') + '>Create and import events</button> <a class="btn btn-link" href="/admin/promotions">Advanced editor</a></form></div></div>';
+}
+
+async function inspectSource(source, sourceId) {
+  const id = String(sourceId || '').trim();
+  if (!id) throw new Error('Source ID is required.');
+  if (source === 'tsdb') {
+    const tsdb = require('./sources/thesportsdb');
+    const results = await Promise.allSettled([tsdb.fetchLeague(id), tsdb.fetchUpcoming(id), tsdb.fetchRecent(id)]);
+    const league = results[0].status === 'fulfilled' ? results[0].value : null;
+    const raw = [].concat(results[1].status === 'fulfilled' ? results[1].value : [], results[2].status === 'fulfilled' ? results[2].value : []);
+    return {
+      poster: league && (league.strBadge || league.strLogo || league.strPoster),
+      fanart: league && (league.strFanart1 || league.strBanner),
+      samples: raw.filter((item) => item && item.strEvent).map((item) => ({ name: item.strEvent, date: item.dateEvent || '' })).slice(0, 8),
+    };
+  }
+  if (source === 'football-data') {
+    const settings = require('./settings');
+    const apiKey = (settings.getFootballData && settings.getFootballData().apiKey) || (config.footballData && config.footballData.apiKey) || '';
+    if (!apiKey) throw new Error('Configure a football-data.org API key first.');
+    const footballData = require('./sources/football-data');
+    const results = await Promise.all([footballData.lookupCompetition({ competitionId: id, apiKey }), footballData.fetchMatches({ competitionId: id, apiKey })]);
+    const competition = results[0] || {};
+    return {
+      poster: competition.emblem || '',
+      fanart: '',
+      samples: (results[1] || []).map((item) => ({
+        name: ((item.homeTeam && (item.homeTeam.shortName || item.homeTeam.name)) || '') + ' vs ' + ((item.awayTeam && (item.awayTeam.shortName || item.awayTeam.name)) || ''),
+        date: String(item.utcDate || '').slice(0, 10),
+      })).filter((item) => !/^\s*vs\s*$/.test(item.name)).slice(0, 8),
+    };
+  }
+  if (source === 'tmdb') {
+    const apiKey = (config.tmdb && config.tmdb.apiKey) || '';
+    if (!apiKey) throw new Error('Configure TMDB_API_KEY first.');
+    const tmdb = require('./sources/tmdb');
+    const show = await tmdb.lookupShow({ tvId: id, apiKey });
+    const seasons = (show.seasons || []).map((item) => Number(item.season_number)).filter((number) => number > 0).sort((a, b) => b - a);
+    const detail = seasons.length ? await tmdb.fetchSeason({ tvId: id, seasonNumber: seasons[0], apiKey }) : { episodes: [] };
+    return {
+      poster: show.poster_path ? 'https://image.tmdb.org/t/p/w780' + show.poster_path : '',
+      fanart: show.backdrop_path ? 'https://image.tmdb.org/t/p/original' + show.backdrop_path : '',
+      samples: (detail.episodes || []).filter((item) => item.air_date).map((item) => ({ name: show.name, date: item.air_date })).slice(-8),
+    };
+  }
+  throw new Error('Unknown source.');
 }
 
 async function discoverSources(source, query) {
@@ -269,4 +365,4 @@ function renderBody(opts) {
   return '<div class="page-header mb-3"><div class="row align-items-center"><div class="col"><h1 class="page-title">Content Studio</h1><div class="text-secondary mt-1">Curate promotions and events without editing JSON or losing changes on refresh.</div></div></div></div>' + flashHtml(opts.flash) + nav(tab) + content;
 }
 
-module.exports = { renderBody, parseImport, applyImport, suggestMatches, discoverSources };
+module.exports = { renderBody, parseImport, applyImport, suggestMatches, discoverSources, inspectSource, inferPromotionSetup };

--- a/lib/promotions.js
+++ b/lib/promotions.js
@@ -71,13 +71,15 @@ function yearMatchesEvent(title, event) {
   const eventYear = parseInt(event.date.slice(0, 4), 10);
   if (!Number.isFinite(eventYear)) return true;
 
-  // Season notation: YYYY-YY or YYYY/YY. Range brackets the event year.
-  const fullSeasonRe = /\b(19|20)(\d{2})[-/](\d{2})\b/g;
+  // Season notation: YYYY-YY, YYYY/YYYY or YYYY-YYYY. Range brackets the
+  // event year. Basketball releases commonly use the full `2025-2026` form.
+  const fullSeasonRe = /\b(19|20)(\d{2})[-/](?:(19|20))?(\d{2})\b/g;
   let m;
   while ((m = fullSeasonRe.exec(title)) !== null) {
     const startYear = parseInt(m[1] + m[2], 10);
-    const endYearShort = parseInt(m[3], 10);
-    const endYear = parseInt(m[1], 10) * 100 + endYearShort;
+    const endYearShort = parseInt(m[4], 10);
+    const endCentury = m[3] ? parseInt(m[3], 10) : parseInt(m[1], 10);
+    const endYear = endCentury * 100 + endYearShort;
     if (eventYear === startYear || eventYear === endYear) return true;
   }
 
@@ -1724,6 +1726,14 @@ function aliasBoundaryMatch(lcTitle, alias) {
   return re.test(lcTitle);
 }
 
+function plainTeamMatch(title, teamName) {
+  const normalise = (value) => String(value || '')
+    .toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim().replace(/\s+/g, ' ');
+  const haystack = ' ' + normalise(title) + ' ';
+  const needle = normalise(teamName);
+  return needle.length >= 3 && haystack.includes(' ' + needle + ' ');
+}
+
 function createGenericPromotion(spec) {
   if (!spec || !spec.id) return null;
   const id = String(spec.id);
@@ -1829,8 +1839,9 @@ function createGenericPromotion(spec) {
       // Also emit league-prefixed variants ("EPL Man United vs Forest") to
       // catch releases whose league prefix comes before the teams.
       let nameVariants = [eventName];
+      const plainSplit = splitMatchup(eventName);
       if (teamAliasLookup) {
-        const split = splitMatchup(eventName);
+        const split = plainSplit;
         if (split) {
           // 0.41.1 — filter to search-worthy forms only. FC/CF-suffixed and
           // fan-nickname forms are relevance-match-only (used later in
@@ -1844,6 +1855,15 @@ function createGenericPromotion(spec) {
         }
       }
 
+      // Generic matchup coverage without a curated alias preset. Metadata
+      // normally uses home vs away; releases often reverse it or use `@`.
+      if (plainSplit) {
+        nameVariants.push(plainSplit.away + ' vs ' + plainSplit.home);
+        nameVariants.push(plainSplit.home + ' @ ' + plainSplit.away);
+        nameVariants.push(plainSplit.away + ' @ ' + plainSplit.home);
+        nameVariants = Array.from(new Set(nameVariants));
+      }
+
       const out = new Set();
       for (const nameVariant of nameVariants) {
         const ctx = { name: nameVariant, year, date };
@@ -1851,6 +1871,12 @@ function createGenericPromotion(spec) {
           const filled = applyTitleTemplate(tpl, ctx).trim().replace(/\s+/g, ' ');
           if (filled) out.add(filled);
         }
+      }
+      if (plainSplit && date) {
+        const parts = date.split('-');
+        const dmy = parts.length === 3 ? parts[2] + '.' + parts[1] + '.' + parts[0] : '';
+        out.add(eventName + ' ' + date);
+        if (dmy) out.add(plainSplit.away + ' @ ' + plainSplit.home + ' ' + dmy);
       }
       // League-prefix variants for the shortest matchup variant only — this
       // keeps the query count bounded while still covering "EPL team-a vs team-b".
@@ -1899,6 +1925,23 @@ function createGenericPromotion(spec) {
         }
       }
 
+      // Canonical team names are still strong evidence when no alias preset
+      // exists. Team order is deliberately irrelevant.
+      if (!teamAliasApplicable && event && event.name) {
+        const split = splitMatchup(event.name);
+        if (split) {
+          teamAliasApplicable = true;
+          teamAliasPassed = plainTeamMatch(title, split.home)
+            && plainTeamMatch(title, split.away);
+        }
+      }
+
+      const dateVerdict = dateMatchesEvent(title, event);
+      // Both teams plus the exact fixture date outrank generated promotion
+      // keywords, which may be overly narrow in quick-created promotions.
+      if (teamAliasPassed && dateVerdict === 'match') return { ok: true };
+      if (teamAliasPassed && dateVerdict === 'wrong-date') return { ok: false, reason: 'wrong-date' };
+
       // Keyword check — enforced UNLESS both team aliases matched above.
       // For non-matchup promotions (UFC PPV, WWE, F1) team-alias is not
       // applicable and the keyword check remains the primary filter.
@@ -1913,7 +1956,6 @@ function createGenericPromotion(spec) {
       // "EPL.2026.05.24.Man.City.vs.Villa" from an old
       // "EPL.2025.05.24.Man.City.vs.Villa" — same teams, different year, both
       // pass a naive team+year check but only one is the fixture we want.
-      const dateVerdict = dateMatchesEvent(title, event);
       if (dateVerdict === 'match') return { ok: true };   // date match is stronger than any other check
       if (dateVerdict === 'wrong-date') return { ok: false, reason: 'wrong-date' };
       // dateVerdict === 'none' — no date detected

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -444,8 +444,9 @@ async function handleStream(params) {
     return { streams: [] };
   }
 
-  const data = store.loadFromDisk();
-  const event = (data.events || []).find((e) => e.id === id);
+  // Read the composed event so Content Studio overrides and search aliases
+  // affect playback exactly as they affect catalog/meta responses.
+  const event = store.getEvent(id);
   if (!event) { log('no event in store for ' + id); return { streams: [] }; }
   const promo = getByEventId(id);
   if (!promo || typeof promo.searchTitles !== 'function') {
@@ -489,13 +490,29 @@ async function handleStream(params) {
   // a timeout warning and return zero — the client still gets fast results.
   const budgetMs = parseInt(process.env.STREAM_PIPELINE_TIMEOUT_MS || '8000', 10);
   function budgeted(name, promise) {
-    return Promise.race([
-      promise.catch((err) => { log('pipeline ' + name + ' failed: ' + err.message); return []; }),
-      new Promise((resolve) => setTimeout(() => {
+    return new Promise((resolve) => {
+      let settled = false;
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
         log('pipeline ' + name + ' TIMEOUT after ' + budgetMs + 'ms — returning empty');
         resolve([]);
-      }, budgetMs)),
-    ]);
+      }, budgetMs);
+      Promise.resolve(promise)
+        .then((rows) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          resolve(rows);
+        })
+        .catch((err) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          log('pipeline ' + name + ' failed: ' + err.message);
+          resolve([]);
+        });
+    });
   }
 
   // 0.42.0 — per-promotion pipeline toggles. `promo.disabledPipelines` is

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serioussportsync",
-  "version": "0.43.1",
+  "version": "0.43.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "serioussportsync",
-      "version": "0.43.1",
+      "version": "0.43.2",
       "license": "MIT",
       "dependencies": {
         "bcryptjs": "^2.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name":  "serioussportsync",
-    "version": "0.43.1",
+    "version": "0.43.2",
     "description":  "Self-hosted Stremio/Nuvio sports metadata calendar with optional per-user TorBox, Usenet Ultimate, and Easynews playback pipelines.",
     "main":  "server.js",
     "scripts":  {


### PR DESCRIPTION
## What changed

- converts Content Studio promotion creation into a guided source wizard
- previews source events and artwork, infers matching defaults, and starts the initial import
- improves generic matchup searches for reversed teams, `@` naming, and exact dates
- fixes full season-year matching, Content Studio override use during playback, and phantom pipeline timeout logs

## Why

Adding a new promotion required users to understand internal IDs, search templates, relevance keywords, and refresh behavior. Generic matchup releases could also be rejected even when both teams and the exact event date matched.

## Validation

- JavaScript syntax check across committed source files
- application module-load smoke test
- NBA, EPL, UFC, and TMDB wizard inference/render regressions
- exact-date generic matchup regression
- `git diff --check`