### PR TITLE
Add hosted Comet streaming for SSS events

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,6 +106,12 @@ PROWLARR_API_KEY=
 # - TorBox API key
 # - Usenet Ultimate manifest URL
 # - Easynews username/password
+# - Comet manifest URL
+#
+# Exact host:port allowlist for per-user Comet manifests. Required for both
+# public and private instances to prevent user-controlled server-side requests.
+# Example: COMET_ALLOWED_HOSTS=comet:8000,192.168.1.16:7003
+COMET_ALLOWED_HOSTS=
 
 # ---- Persistent stream cache + proactive warmer ----------------------------
 # Caches candidate releases and optionally pre-fills recent events. This is

--- a/.github/workflows/aiostreams-poc-container.yml
+++ b/.github/workflows/aiostreams-poc-container.yml
@@ -1,0 +1,36 @@
+name: AIOStreams POC container
+
+on:
+  push:
+    branches: [agent/aiostreams-bridge]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Sign in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish test image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64
+          tags: ghcr.io/monkfish1337/serioussportsync:aiostreams-poc
+          labels: org.opencontainers.image.source=https://github.com/${{ github.repository }}
+          cache-from: type=gha,scope=aiostreams-poc-amd64
+          cache-to: type=gha,mode=max,scope=aiostreams-poc-amd64

--- a/.github/workflows/aiostreams-poc-container.yml
+++ b/.github/workflows/aiostreams-poc-container.yml
@@ -1,4 +1,4 @@
-name: AIOStreams POC container
+name: AIOStreams POC containers
 
 on:
   push:
@@ -10,7 +10,7 @@ permissions:
   packages: write
 
 jobs:
-  publish:
+  publish-serioussportsync:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -34,3 +34,39 @@ jobs:
           labels: org.opencontainers.image.source=https://github.com/${{ github.repository }}
           cache-from: type=gha,scope=aiostreams-poc-amd64
           cache-to: type=gha,mode=max,scope=aiostreams-poc-amd64
+
+  publish-aiostreams:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out AIOStreams integration fork
+        uses: actions/checkout@v4
+        with:
+          repository: Monkfish1337/AIOStreams
+          ref: agent/serioussportsync-poc
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Generate build metadata
+        run: node scripts/generateMetadata.cjs --channel=dev --ref=sss-poc --commit="$(git rev-parse --short HEAD)"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Sign in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish AIOStreams test image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64
+          tags: ghcr.io/monkfish1337/aiostreams:sss-poc
+          labels: org.opencontainers.image.source=https://github.com/Monkfish1337/AIOStreams
+          cache-from: type=gha,scope=sss-poc-aiostreams-amd64
+          cache-to: type=gha,mode=max,scope=sss-poc-aiostreams-amd64

--- a/.github/workflows/aiostreams-poc-container.yml
+++ b/.github/workflows/aiostreams-poc-container.yml
@@ -66,7 +66,7 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64
-          tags: ghcr.io/monkfish1337/aiostreams:sss-poc
-          labels: org.opencontainers.image.source=https://github.com/Monkfish1337/AIOStreams
+          tags: ghcr.io/monkfish1337/serioussportsync-aiostreams:sss-poc
+          labels: org.opencontainers.image.source=https://github.com/${{ github.repository }}
           cache-from: type=gha,scope=sss-poc-aiostreams-amd64
           cache-to: type=gha,mode=max,scope=sss-poc-aiostreams-amd64

--- a/.github/workflows/aiostreams-poc-container.yml
+++ b/.github/workflows/aiostreams-poc-container.yml
@@ -15,6 +15,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Validate integration contracts
+        run: |
+          npm ci --no-audit --no-fund
+          npm run test:comet
+          npm run test:search-context
+          npm run test:uu
+
       - uses: docker/setup-buildx-action@v3
 
       - name: Sign in to GitHub Container Registry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
               './lib/sources/realdebrid',
               './lib/sources/torbox',
               './lib/sources/premiumize',
+              './lib/sources/comet',
             ];
             for (const m of mods) {
               try { require(m); }
@@ -96,6 +97,12 @@ jobs:
             }
             console.log('OK — all modules load, promotion registry well-formed (' + p.enabled.length + ' enabled).');
           "
+
+      - name: Integration contract tests
+        run: |
+          npm run test:comet
+          npm run test:search-context
+          npm run test:uu
 
   docker:
     name: Docker Compose smoke test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Per-user Comet stream provider
+
+- Added a Comet manifest field to each SSS account. SSS remains the installed
+  catalog addon and forwards event stream requests to the user's compatible
+  Comet instance, keeping all sports catalogs visible in Stremio and Nuvio.
+- Added connection testing, encrypted-at-rest manifest storage, an enable
+  switch, and per-promotion Comet pipeline controls.
+
 ### Provider-owned Usenet Ultimate discovery
 
 - Replaced SSS's server-wide Newznab search with manifest-scoped direct title

--- a/README.md
+++ b/README.md
@@ -54,8 +54,25 @@ returns only the rows that finish within the configured request budget.
 | --- | --- | --- |
 | Direct Prowlarr | TorBox | Searches when an event is opened, checks the user's cache, and resolves on play |
 | Companion scraper | TorBox | Combines Prowlarr, Zilean, Torznab, and other configured companion sources |
+| Comet manifest | Comet-configured debrid | Keeps SSS installed for catalogs while forwarding event stream requests to a compatible public or self-hosted Comet instance |
 | Usenet Ultimate | Usenet Ultimate / NzbDAV | Sends event title variants to the user's UU instance; UU searches its configured indexers and handles playback |
 | Easynews | Easynews | Searches and plays with credentials stored on the user's account |
+
+### Comet integration
+
+The SSS operator first allows trusted Comet hosts with
+`COMET_ALLOWED_HOSTS` (exact `host:port`, comma-separated). Each user then:
+
+1. Copies their private SSS manifest from **Account → Services → Comet**.
+2. Configures a compatible Comet instance with that SSS manifest and their
+   debrid service.
+3. Pastes the generated Comet manifest back into their SSS account and uses
+   **Test** before saving.
+4. Installs only the SSS manifest in Nuvio or Stremio. SSS supplies the sports
+   catalogs while Comet supplies scraper results and playback.
+
+The Comet manifest is encrypted at rest. Local HTTP, LAN, and Docker service
+URLs work when their exact host and port are included in the allowlist.
 
 > **Usenet Ultimate compatibility:** direct sports-title search requires the
 > endpoint proposed in [Usenet Ultimate PR #46](https://github.com/DSmart33/Usenet-Ultimate/pull/46).

--- a/addon.js
+++ b/addon.js
@@ -9,6 +9,7 @@ const { handleStream, resolvePlay } = require('./lib/streams');
 const store = require('./lib/store');
 const streamcache = require('./lib/streamcache');
 const settings = require('./lib/settings');
+const cometSource = require('./lib/sources/comet');
 const { runStreamRefresh, readStatus: readWarmerStatus } = require('./scripts/refresh-streams');
 const { runRefresh: runEventsRefresh } = require('./scripts/refresh');
 const promotions = require('./lib/promotions');
@@ -301,6 +302,8 @@ function createApp() {
       // longer touched by the UI. The schema still includes them in users.js
       // so existing records continue deserialising cleanly.
       users.updateUserConfig(req.user.id, {
+        cometManifestUrl: String(b.cometManifestUrl || '').trim(),
+        cometEnabled: b.cometEnabled === 'on' || b.cometEnabled === '1' || b.cometEnabled === 'true',
         uuManifestUrl: String(b.uuManifestUrl || '').trim(),
         torboxApiKey: String(b.torboxApiKey || '').trim(),
         easynewsUsername: String(b.easynewsUsername || '').trim(),
@@ -314,6 +317,18 @@ function createApp() {
     } catch (err) {
       res.redirect('/account?flash=' + encodeURIComponent('Save failed: ' + err.message));
     }
+  });
+
+  app.post('/account/test-comet', requireLogin, async (req, res) => {
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    const manifestUrl = String((req.body && req.body.cometManifestUrl) || '').trim();
+    const expectedSssManifestUrl = publicOriginFromReq(req) + '/u/'
+      + req.user.id + '/' + req.user.apiToken + '/manifest.json';
+    const result = await cometSource.testManifest(manifestUrl, {
+      timeoutMs: 10000,
+      expectedSssManifestUrl,
+    });
+    res.status(result.ok ? 200 : 400).send(JSON.stringify(result));
   });
 
   app.post('/account/regenerate-token', requireLogin, (req, res) => {
@@ -2019,6 +2034,34 @@ function renderAccountPage(user, opts) {
   // Services tab — credentials for each provider.
   const servicesTab = ''
     + '<div class="card mb-3">'
+    +   '<div class="card-header"><h3 class="card-title">Comet</h3><span class="badge bg-azure-lt ms-2">Hosted scrapers</span></div>'
+    +   '<div class="card-body">'
+    +     '<p class="text-secondary small mb-3">Use a compatible public or self-hosted Comet instance as a background stream provider. SeriousSportSync remains the only addon you install, so all sports catalogs stay visible in Nuvio and Stremio.</p>'
+    +     '<ol class="text-secondary small ps-3 mb-3">'
+    +       '<li>Copy your SSS manifest below and paste it into Comet\'s <strong>SeriousSportSync</strong> setting.</li>'
+    +       '<li>Configure your debrid service in Comet and generate its manifest.</li>'
+    +       '<li>Paste that Comet manifest back here, test it, then save.</li>'
+    +     '</ol>'
+    +     '<label class="form-label">Your SSS manifest for Comet</label>'
+    +     '<div class="input-group mb-3">'
+    +       '<input class="form-control text-mono" id="sss-url-for-comet" value="' + escapeHtml(installUrl) + '" readonly>'
+    +       '<button class="btn btn-outline-secondary" type="button" id="copySssForCometBtn">Copy</button>'
+    +     '</div>'
+    +     '<label class="form-label">Configured Comet manifest URL</label>'
+    +     '<div class="input-group input-group-flat mb-2">'
+    +       '<input class="form-control text-mono" type="password" id="comet-url" name="cometManifestUrl" value="' + escapeHtml(cfg.cometManifestUrl || '') + '" placeholder="https://comet.example/&lt;config&gt;/manifest.json" autocomplete="off">'
+    +       '<span class="input-group-text"><a href="#" class="link-secondary btn-reveal" tabindex="-1">Show</a></span>'
+    +       '<button class="btn btn-outline-primary" type="button" id="testCometBtn">Test</button>'
+    +     '</div>'
+    +     '<div class="small text-secondary mb-3" id="cometTestStatus">The URL contains your Comet and debrid configuration and is encrypted at rest.</div>'
+    +     '<label class="form-check form-switch mb-0">'
+    +       '<input class="form-check-input" type="checkbox" name="cometEnabled" value="on"' + ((cfg.cometEnabled !== false) ? ' checked' : '') + '>'
+    +       '<span class="form-check-label">Include Comet results</span>'
+    +     '</label>'
+    +   '</div>'
+    + '</div>'
+
+    + '<div class="card mb-3">'
     +   '<div class="card-header"><h3 class="card-title">TorBox</h3></div>'
     +   '<div class="card-body">'
     +     '<p class="text-secondary small mb-3">Used by the addon to check which scraper results are already cached on your TorBox subscription, and to return playable URLs only for cached items. Your key never leaves this addon.</p>'
@@ -2143,6 +2186,19 @@ function renderAccountPage(user, opts) {
     +     'var t = code.value;'
     +     'if (navigator.clipboard) { navigator.clipboard.writeText(t); }'
     +     'btn.textContent = "Copied!"; setTimeout(function(){ btn.textContent = "Copy"; }, 1800);'
+    +   '});'
+    + '})();'
+    + '(function(){'
+    +   'var btn=document.getElementById("copySssForCometBtn"), input=document.getElementById("sss-url-for-comet");'
+    +   'if(btn&&input)btn.addEventListener("click",function(){if(navigator.clipboard)navigator.clipboard.writeText(input.value);btn.textContent="Copied!";setTimeout(function(){btn.textContent="Copy";},1800);});'
+    +   'var testBtn=document.getElementById("testCometBtn"), url=document.getElementById("comet-url"), status=document.getElementById("cometTestStatus");'
+    +   'if(testBtn&&url&&status)testBtn.addEventListener("click",function(){'
+    +     'testBtn.disabled=true;status.className="small text-secondary mb-3";status.textContent="Testing Comet…";'
+    +     'fetch("/account/test-comet",{method:"POST",headers:{"Content-Type":"application/x-www-form-urlencoded"},body:"cometManifestUrl="+encodeURIComponent(url.value)})'
+    +       '.then(function(r){return r.json().then(function(j){return {ok:r.ok,data:j};});})'
+    +       '.then(function(out){var d=out.data||{};if(out.ok&&d.supportsSss&&d.matchesSss!==false){status.className="small text-success mb-3";status.textContent=(d.name||"Comet")+" is ready for this SeriousSportSync account.";}else if(out.ok){status.className="small text-warning mb-3";status.textContent=d.warning||"Comet is reachable but SSS support is not configured.";}else{status.className="small text-danger mb-3";status.textContent=d.error||"Comet test failed.";}})'
+    +       '.catch(function(e){status.className="small text-danger mb-3";status.textContent="Comet test failed: "+e.message;})'
+    +       '.finally(function(){testBtn.disabled=false;});'
     +   '});'
     + '})();'
     + 'document.addEventListener("click", function(e){'

--- a/addon.js
+++ b/addon.js
@@ -4,6 +4,7 @@ const config = require('./config');
 const { buildManifest } = require('./lib/manifest');
 const { handleCatalog } = require('./lib/catalog');
 const { handleMeta } = require('./lib/meta');
+const { handleSearchContext } = require('./lib/search-context');
 const { handleStream, resolvePlay } = require('./lib/streams');
 const store = require('./lib/store');
 const streamcache = require('./lib/streamcache');
@@ -357,6 +358,18 @@ function createApp() {
 
     r.get('/meta/:type/:id.json', (req, res) => {
       send(res, handleMeta({ type: req.params.type, id: decodeURIComponent(req.params.id) }));
+    });
+
+    // Event-aware title resolver for aggregator integrations. This is scoped
+    // to the same tokenised user URL as the manifest, so disabling/regenerating
+    // an install token also disables the resolver URL held by an aggregator.
+    r.get('/search-context/:type/:id.json', (req, res) => {
+      const context = handleSearchContext({
+        type: req.params.type,
+        id: decodeURIComponent(req.params.id),
+      });
+      if (!context) return res.status(404).json({ error: 'event-not-found' });
+      send(res, context, { cacheControl: 'public, max-age=3600' });
     });
 
     r.get('/stream/:type/:id.json', async (req, res) => {

--- a/lib/admin-promotions.js
+++ b/lib/admin-promotions.js
@@ -360,26 +360,33 @@ function renderBody(opts) {
           <h4 class="mb-2">Pipeline toggles <span class="badge bg-secondary-lt ms-2">optional</span></h4>
           <p class="text-secondary small mb-3">Disable specific stream pipelines for events from this promotion. A disabled provider is skipped entirely — no query and no wait.</p>
           <div class="row">
-            <div class="col-md-4 mb-2">
+            <div class="col-md-3 mb-2">
               <label class="form-check">
                 <input class="form-check-input" type="checkbox" name="disablePipelineTorbox" value="1"${(ed.disabledPipelines && ed.disabledPipelines.indexOf('torbox') !== -1) ? ' checked' : ''}>
                 <span class="form-check-label">Disable TorBox pipeline</span>
               </label>
               <small class="text-secondary d-block">Skips companion scraper → Prowlarr/Zilean/Bitmagnet → TorBox cache check.</small>
             </div>
-            <div class="col-md-4 mb-2">
+            <div class="col-md-3 mb-2">
               <label class="form-check">
                 <input class="form-check-input" type="checkbox" name="disablePipelineUu" value="1"${(ed.disabledPipelines && (ed.disabledPipelines.indexOf('uu') !== -1 || ed.disabledPipelines.indexOf('newsnab') !== -1)) ? ' checked' : ''}>
                 <span class="form-check-label">Disable Usenet Ultimate pipeline</span>
               </label>
               <small class="text-secondary d-block">Skips UU's direct event-title search and NzbDAV playback.</small>
             </div>
-            <div class="col-md-4 mb-2">
+            <div class="col-md-3 mb-2">
               <label class="form-check">
                 <input class="form-check-input" type="checkbox" name="disablePipelineEasynews" value="1"${(ed.disabledPipelines && ed.disabledPipelines.indexOf('easynews') !== -1) ? ' checked' : ''}>
                 <span class="form-check-label">Disable Easynews pipeline</span>
               </label>
               <small class="text-secondary d-block">Skips per-user Easynews direct search.</small>
+            </div>
+            <div class="col-md-3 mb-2">
+              <label class="form-check">
+                <input class="form-check-input" type="checkbox" name="disablePipelineComet" value="1"${(ed.disabledPipelines && ed.disabledPipelines.indexOf('comet') !== -1) ? ' checked' : ''}>
+                <span class="form-check-label">Disable Comet pipeline</span>
+              </label>
+              <small class="text-secondary d-block">Skips the user\'s configured hosted Comet stream provider.</small>
             </div>
           </div>
 
@@ -458,6 +465,7 @@ function saveFromForm(body, opts) {
       body.disablePipelineTorbox === '1'   ? 'torbox'   : null,
       body.disablePipelineUu === '1'       ? 'uu'       : null,
       body.disablePipelineEasynews === '1' ? 'easynews' : null,
+      body.disablePipelineComet === '1'    ? 'comet'    : null,
     ].filter(Boolean),
     // 0.42.6 — date-strict matching. Checkbox is ALWAYS in the form when we
     // render it, so we can treat unchecked as an explicit `false`. This lets

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -13,14 +13,15 @@ function buildManifest(opts) {
   const userCfg = (opts.user && opts.user.config) || null;
 
   // Advertise streams only when one of the current playback pipelines is
-  // available: torrent discovery, per-user Usenet Ultimate, or per-user Easynews.
+  // available: torrent discovery, per-user Comet, Usenet Ultimate, or Easynews.
   const companion = settings.getCompanion();
   const prowlarr = settings.getProwlarr();
   const haveCompanion = !!(companion && companion.url);
   const haveProwlarr = !!(prowlarr.url && prowlarr.apiKey);
+  const haveComet = !!(userCfg && userCfg.cometManifestUrl && userCfg.cometEnabled !== false);
   const haveUU = !!(userCfg && userCfg.uuManifestUrl);
   const haveEasynews = !!(userCfg && userCfg.easynewsUsername && userCfg.easynewsPassword);
-  const streamEnabled = haveCompanion || haveProwlarr || haveUU || haveEasynews;
+  const streamEnabled = haveCompanion || haveProwlarr || haveComet || haveUU || haveEasynews;
 
   const idPrefixes = promotions.enabled.map((p) => p.idPrefix + ':');
 

--- a/lib/search-context.js
+++ b/lib/search-context.js
@@ -1,0 +1,54 @@
+const config = require('../config');
+const store = require('./store');
+const promotions = require('./promotions');
+
+function uniqueStrings(values) {
+  const seen = new Set();
+  const out = [];
+  for (const value of values || []) {
+    const title = String(value || '').trim();
+    if (!title) continue;
+    const key = title.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(title);
+  }
+  return out;
+}
+
+// Machine-readable event context for trusted aggregator integrations such as
+// AIOStreams. The endpoint deliberately accepts only an existing SSS event ID;
+// it is not an arbitrary search proxy and contains no user service credentials.
+function handleSearchContext({ type, id }) {
+  if (type !== config.addonType) return null;
+
+  const event = store.getEvent(id);
+  if (!event) return null;
+
+  const promotion = promotions.getByEventId(id);
+  if (!promotion || typeof promotion.searchTitles !== 'function') return null;
+
+  const searchTitles = uniqueStrings([
+    ...(promotion.searchTitles(event) || []),
+    ...(event.searchAliases || []),
+    ...(event.aliases || []),
+    event.name,
+  ]);
+  const date = event.dateLocal || event.date || null;
+  const year = date && /^\d{4}/.test(date) ? Number(date.slice(0, 4)) : null;
+
+  return {
+    version: 1,
+    id: event.id,
+    type: config.addonType,
+    title: event.name,
+    searchTitles,
+    date,
+    year,
+    promotion: event.promotion || promotion.id,
+    sport: event.sport || promotion.sport || null,
+    country: event.country || null,
+  };
+}
+
+module.exports = { handleSearchContext };

--- a/lib/sources/comet.js
+++ b/lib/sources/comet.js
@@ -87,6 +87,16 @@ function decodeConfiguredManifest(manifestUrl) {
   }
 }
 
+function sameManifestAccount(first, second) {
+  try {
+    const a = new URL(first);
+    const b = new URL(second);
+    return a.pathname === b.pathname;
+  } catch (_) {
+    return false;
+  }
+}
+
 async function testManifest(manifestUrl, options) {
   const opts = options || {};
   const comet = parseManifestUrl(manifestUrl);
@@ -104,7 +114,7 @@ async function testManifest(manifestUrl, options) {
       ? embedded.seriousSportsSyncManifestUrl.trim() : '';
     const supportsSss = !!configuredSss;
     const expectedSss = String(opts.expectedSssManifestUrl || '').trim();
-    const matchesSss = !expectedSss || configuredSss === expectedSss;
+    const matchesSss = !expectedSss || sameManifestAccount(configuredSss, expectedSss);
     return {
       ok: true,
       name: String(payload.name || 'Comet'),

--- a/lib/sources/comet.js
+++ b/lib/sources/comet.js
@@ -1,0 +1,128 @@
+// Per-user Comet manifest forwarding.
+//
+// SeriousSportSync remains the installed catalog/meta addon. When an event is
+// opened, SSS asks the configured Comet manifest's matching stream endpoint
+// for that SSS event ID and returns the resulting rows unchanged. Playback
+// therefore stays on Comet and the user's configured debrid service.
+
+const fetch = require('node-fetch');
+const httpAgent = require('../http-agent');
+
+function allowedHosts() {
+  return new Set(String(process.env.COMET_ALLOWED_HOSTS || '')
+    .split(',').map((host) => host.trim().toLowerCase()).filter(Boolean));
+}
+
+function parseManifestUrl(manifestUrl) {
+  if (!manifestUrl || typeof manifestUrl !== 'string') return null;
+  let parsed;
+  try { parsed = new URL(manifestUrl.trim()); } catch (_) { return null; }
+  if (!['http:', 'https:'].includes(parsed.protocol)) return null;
+  if (parsed.username || parsed.password) return null;
+  if (!parsed.pathname.endsWith('/manifest.json')) return null;
+  parsed.hash = '';
+  parsed.search = '';
+
+  const allowlist = allowedHosts();
+  const host = parsed.host.toLowerCase();
+  if (allowlist.size === 0 || !allowlist.has(host)) return null;
+
+  return {
+    manifestUrl: parsed.toString(),
+    streamBase: parsed.toString().slice(0, -'manifest.json'.length),
+  };
+}
+
+function buildStreamUrl(comet, mediaType, mediaId) {
+  if (!comet || !comet.streamBase || !mediaType || !mediaId) return null;
+  return comet.streamBase + 'stream/' + encodeURIComponent(mediaType)
+    + '/' + encodeURIComponent(mediaId) + '.json';
+}
+
+async function fetchJson(url, timeoutMs) {
+  const response = await fetch(url, httpAgent.fetchOpts({
+    headers: { Accept: 'application/json' },
+    timeout: timeoutMs || 15000,
+    redirect: 'manual',
+  }, url));
+  if (!response.ok) throw new Error('HTTP ' + response.status);
+  const payload = await response.json();
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new Error('invalid JSON response');
+  }
+  return payload;
+}
+
+async function getStreams(mediaType, mediaId, comet, options) {
+  const opts = options || {};
+  const log = opts.log || (() => {});
+  if (!comet) return [];
+  const url = buildStreamUrl(comet, mediaType, mediaId);
+  if (!url) return [];
+  log('comet: requesting event streams');
+  try {
+    const payload = await fetchJson(url, opts.timeoutMs);
+    const rows = Array.isArray(payload.streams)
+      ? payload.streams.filter((row) => row && typeof row === 'object')
+      : [];
+    log('comet: received ' + rows.length + ' stream row(s)');
+    return rows;
+  } catch (err) {
+    log('comet: request failed: ' + err.message);
+    return [];
+  }
+}
+
+function decodeConfiguredManifest(manifestUrl) {
+  try {
+    const parsed = new URL(manifestUrl);
+    const parts = parsed.pathname.split('/').filter(Boolean);
+    if (parts.length < 2 || parts[parts.length - 1] !== 'manifest.json') return null;
+    const encoded = decodeURIComponent(parts[parts.length - 2]);
+    const json = Buffer.from(encoded, 'base64').toString('utf8');
+    const config = JSON.parse(json);
+    return config && typeof config === 'object' ? config : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+async function testManifest(manifestUrl, options) {
+  const opts = options || {};
+  const comet = parseManifestUrl(manifestUrl);
+  if (!comet) {
+    return { ok: false, error: 'Invalid or untrusted Comet manifest URL' };
+  }
+  try {
+    const payload = await fetchJson(comet.manifestUrl, opts.timeoutMs || 10000);
+    const resources = Array.isArray(payload.resources) ? payload.resources : [];
+    const hasStreams = resources.some((resource) => resource === 'stream'
+      || (resource && resource.name === 'stream'));
+    if (!hasStreams) return { ok: false, error: 'Manifest does not provide streams' };
+    const embedded = decodeConfiguredManifest(comet.manifestUrl);
+    const configuredSss = embedded && typeof embedded.seriousSportsSyncManifestUrl === 'string'
+      ? embedded.seriousSportsSyncManifestUrl.trim() : '';
+    const supportsSss = !!configuredSss;
+    const expectedSss = String(opts.expectedSssManifestUrl || '').trim();
+    const matchesSss = !expectedSss || configuredSss === expectedSss;
+    return {
+      ok: true,
+      name: String(payload.name || 'Comet'),
+      supportsSss,
+      matchesSss,
+      warning: !supportsSss
+        ? 'Comet is reachable but its configuration does not include a SeriousSportSync manifest URL.'
+        : (!matchesSss ? 'Comet is configured with a different SeriousSportSync account manifest.' : ''),
+    };
+  } catch (err) {
+    return { ok: false, error: err.message || 'Connection failed' };
+  }
+}
+
+module.exports = {
+  parseManifestUrl,
+  buildStreamUrl,
+  getStreams,
+  decodeConfiguredManifest,
+  testManifest,
+};

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -1,6 +1,6 @@
 // Stream handler.
 //
-// Three playback pipelines run in parallel. Pipeline A can discover torrents
+// Four playback pipelines run in parallel. Pipeline A can discover torrents
 // through the companion scraper, direct Prowlarr, or both:
 //
 //   Pipeline A (debrid path): torrent discovery -> noise + relevance
@@ -18,8 +18,11 @@
 //     /resolve/easynews injects basic auth + 302-redirects to Easynews
 //     CDN. Creds never appear in /stream responses or log buffers.
 //
+//   Pipeline D (Comet): event ID -> user's configured Comet stream endpoint
+//     -> Comet-hosted scrapers + the user's Comet debrid playback.
+//
 // Per-user requirements:
-//   - At least one of `torboxApiKey`, `uuManifestUrl`, or
+//   - At least one of `cometManifestUrl`, `torboxApiKey`, `uuManifestUrl`, or
 //     `easynewsUsername`+`easynewsPassword` on /account.
 //
 // Admin requirements:
@@ -30,6 +33,7 @@ const store = require('./store');
 const { getByEventId } = require('./promotions');
 const releaseFilter = require('./sources/release-filter');
 const uu = require('./sources/usenet-ultimate');
+const comet = require('./sources/comet');
 const companion = require('./sources/companion-scraper');
 const prowlarr = require('./sources/prowlarr');
 const easynews = require('./sources/easynews');
@@ -430,6 +434,14 @@ async function pipelineUsenetUltimate({ promo, event, titles, uuConfig, log }) {
   return uu.buildStreamRows(relevant.slice(0, MAX_ROWS), uuConfig, event.name);
 }
 
+// Pipeline D — Comet owns discovery, debrid filtering, and playback. SSS sends
+// only its event ID; the configured Comet instance resolves title/date context
+// through the user's token-scoped SSS manifest.
+async function pipelineComet({ event, cometConfig, log }) {
+  if (!cometConfig) { log('comet: not configured — skipping pipeline D'); return []; }
+  return comet.getStreams('movie', event.id, cometConfig, { log });
+}
+
 async function handleStream(params) {
   const log = makeLogger(params);
   const id = params.id;
@@ -454,6 +466,9 @@ async function handleStream(params) {
   }
 
   const userConfig = params.userConfig || {};
+  const cometManifest = userConfig.cometEnabled === false
+    ? '' : String(userConfig.cometManifestUrl || '').trim();
+  const cometConfig = cometManifest ? comet.parseManifestUrl(cometManifest) : null;
   const torboxKey = (userConfig.torboxApiKey || '').trim();
   const uuManifest = (userConfig.uuManifestUrl || '').trim();
   const uuConfig = uuManifest ? uu.parseManifestUrl(uuManifest) : null;
@@ -509,7 +524,7 @@ async function handleStream(params) {
   }
 
   // 0.42.0 — per-promotion pipeline toggles. `promo.disabledPipelines` is
-  // an array of pipeline names ('torbox' | 'uu' | 'easynews') that
+  // an array of pipeline names ('comet' | 'torbox' | 'uu' | 'easynews') that
   // should be skipped for events from this promotion. Lets an operator
   // disable the slow-and-useless-here TorBox pipeline for football events
   // where UU carries all the water.
@@ -525,18 +540,19 @@ async function handleStream(params) {
     return budgeted(name, factory());
   }
 
-  const [torboxRows, uuRows, easynewsRows] = await Promise.all([
+  const [cometRows, torboxRows, uuRows, easynewsRows] = await Promise.all([
+    runOrSkip('comet',    () => pipelineComet({ event, cometConfig, log })),
     runOrSkip('torbox',   () => pipelineTorrentTorbox({ promo, event, titles, torboxKey, urlCtx, log })),
     runOrSkip('uu',       () => pipelineUsenetUltimate({ promo, event, titles, uuConfig, log })),
     runOrSkip('easynews', () => pipelineEasynews({ promo, event, titles, easynewsCreds, urlCtx, log })),
   ]);
 
   // Merge with title-based dedupe (same release surfaced via multiple
-  // backends). Order: TorBox -> UU -> Easynews so the highest-priority
-  // backend wins the slot when titles collide.
+  // backends). Order: Comet -> TorBox -> UU -> Easynews so the configured
+  // hosted aggregator wins the slot when titles collide.
   const seen = new Set();
   const merged = [];
-  for (const set of [torboxRows, uuRows, easynewsRows]) {
+  for (const set of [cometRows, torboxRows, uuRows, easynewsRows]) {
     for (const row of set) {
       const key = row && row.title ? row.title.split('\n')[0] : null;
       if (!key) { merged.push(row); continue; }

--- a/lib/users.js
+++ b/lib/users.js
@@ -26,7 +26,7 @@ const USERS_FILE = config.usersFile || './data/users.json';
 // Easynews username is not encrypted (it appears in audit logs to identify
 // which account a search came from); password is. Existing rd/tb/pm entries
 // kept for backward-compat with pre-0.33.0 user records.
-const SECRET_FIELDS = ['rd', 'tb', 'pm', 'torboxApiKey', 'easynewsPassword'];
+const SECRET_FIELDS = ['rd', 'tb', 'pm', 'torboxApiKey', 'easynewsPassword', 'cometManifestUrl'];
 
 function encryptUserKeysInPlace(user) {
   if (!user || !user.config) return;
@@ -156,6 +156,8 @@ async function createUser({ username, password, role }) {
     // search). Username + password (basic-auth-in-URL at play-time).
     // Legacy rd/tb/pm preserved for backward compat with old user JSON.
     config: {
+      cometManifestUrl: '',
+      cometEnabled: true,
       uuManifestUrl: '',
       torboxApiKey: '',
       easynewsUsername: '',

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
                     "refresh-streams":  "node scripts/refresh-streams.js",
                     "gen-token":  "node scripts/gen-token.js",
                     "dev":  "node server.js",
-                    "test:uu": "node scripts/test-uu-direct-search.js"
+                    "test:uu": "node scripts/test-uu-direct-search.js",
+                    "test:search-context": "node scripts/test-search-context.js"
                 },
     "keywords":  [
                      "stremio",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name":  "serioussportsync",
     "version": "0.43.2",
-    "description":  "Self-hosted Stremio/Nuvio sports metadata calendar with optional per-user TorBox, Usenet Ultimate, and Easynews playback pipelines.",
+    "description":  "Self-hosted Stremio/Nuvio sports metadata calendar with optional per-user Comet, TorBox, Usenet Ultimate, and Easynews playback pipelines.",
     "main":  "server.js",
     "scripts":  {
                     "start":  "node server.js",
@@ -10,7 +10,8 @@
                     "gen-token":  "node scripts/gen-token.js",
                     "dev":  "node server.js",
                     "test:uu": "node scripts/test-uu-direct-search.js",
-                    "test:search-context": "node scripts/test-search-context.js"
+                    "test:search-context": "node scripts/test-search-context.js",
+                    "test:comet": "node scripts/test-comet-forwarding.js"
                 },
     "keywords":  [
                      "stremio",

--- a/scripts/test-comet-forwarding.js
+++ b/scripts/test-comet-forwarding.js
@@ -1,0 +1,60 @@
+const assert = require('assert');
+const http = require('http');
+
+async function main() {
+  let streamPath = '';
+  const config = Buffer.from(JSON.stringify({
+    seriousSportsSyncManifestUrl: 'https://sports.example/u/user/token/manifest.json',
+    debridService: 'torbox',
+  })).toString('base64');
+  const server = http.createServer((req, res) => {
+    res.setHeader('Content-Type', 'application/json');
+    if (req.url.endsWith('/manifest.json')) {
+      res.end(JSON.stringify({ id: 'comet', name: 'Comet Test', resources: [{ name: 'stream', types: ['movie'] }] }));
+      return;
+    }
+    if (req.url.includes('/stream/movie/')) {
+      streamPath = req.url;
+      res.end(JSON.stringify({ streams: [{ name: 'Comet', title: 'NBA fixture', url: 'https://play.example/video' }] }));
+      return;
+    }
+    res.statusCode = 404;
+    res.end('{}');
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  process.env.COMET_ALLOWED_HOSTS = '127.0.0.1:' + address.port;
+  const comet = require('../lib/sources/comet');
+  const manifestUrl = 'http://127.0.0.1:' + address.port + '/' + encodeURIComponent(config) + '/manifest.json';
+
+  try {
+    const parsed = comet.parseManifestUrl(manifestUrl);
+    assert(parsed, 'allowlisted Comet URL should parse');
+    assert.strictEqual(comet.buildStreamUrl(parsed, 'movie', 'nba:2371750'), parsed.streamBase + 'stream/movie/nba%3A2371750.json');
+    assert.strictEqual(comet.decodeConfiguredManifest(manifestUrl).seriousSportsSyncManifestUrl, 'https://sports.example/u/user/token/manifest.json');
+
+    const connection = await comet.testManifest(manifestUrl, {
+      expectedSssManifestUrl: 'https://sports.example/u/user/token/manifest.json',
+    });
+    assert.strictEqual(connection.ok, true);
+    assert.strictEqual(connection.supportsSss, true);
+    assert.strictEqual(connection.matchesSss, true);
+
+    const rows = await comet.getStreams('movie', 'nba:2371750', parsed);
+    assert.strictEqual(rows.length, 1);
+    assert.strictEqual(rows[0].url, 'https://play.example/video');
+    assert(streamPath.includes('nba%3A2371750.json'));
+
+    process.env.COMET_ALLOWED_HOSTS = '';
+    assert.strictEqual(comet.parseManifestUrl(manifestUrl), null, 'private HTTP must require an allowlist');
+    console.log('Comet forwarding tests passed');
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/test-comet-forwarding.js
+++ b/scripts/test-comet-forwarding.js
@@ -41,6 +41,11 @@ async function main() {
     assert.strictEqual(connection.supportsSss, true);
     assert.strictEqual(connection.matchesSss, true);
 
+    const dockerConnection = await comet.testManifest(manifestUrl, {
+      expectedSssManifestUrl: 'http://serioussportsync-test:7000/u/user/token/manifest.json',
+    });
+    assert.strictEqual(dockerConnection.matchesSss, true);
+
     const rows = await comet.getStreams('movie', 'nba:2371750', parsed);
     assert.strictEqual(rows.length, 1);
     assert.strictEqual(rows[0].url, 'https://play.example/video');

--- a/scripts/test-search-context.js
+++ b/scripts/test-search-context.js
@@ -1,0 +1,34 @@
+const assert = require('assert');
+const store = require('../lib/store');
+const promotions = require('../lib/promotions');
+
+store.getEvent = () => ({
+  id: 'nba:12345',
+  promotion: 'nba',
+  name: 'Dallas Mavericks vs Chicago Bulls',
+  date: '2026-04-12',
+  aliases: ['Chicago Bulls @ Dallas Mavericks'],
+  searchAliases: ['NBA Mavericks Bulls'],
+});
+promotions.getByEventId = () => ({
+  id: 'nba',
+  sport: 'Basketball',
+  searchTitles: () => [
+    'Dallas Mavericks vs Chicago Bulls',
+    'Dallas Mavericks vs Chicago Bulls 2026',
+  ],
+});
+
+const { handleSearchContext } = require('../lib/search-context');
+const context = handleSearchContext({ type: 'movie', id: 'nba:12345' });
+
+assert(context);
+assert.strictEqual(context.year, 2026);
+assert(context.searchTitles.includes('Chicago Bulls @ Dallas Mavericks'));
+assert(context.searchTitles.includes('Dallas Mavericks vs Chicago Bulls 2026'));
+assert.strictEqual(
+  handleSearchContext({ type: 'series', id: 'nba:12345' }),
+  null
+);
+
+console.log('SeriousSportSync search-context test passed');


### PR DESCRIPTION
## What changed

- Adds a token-scoped `search-context` endpoint for SSS events, exposing curated titles, aliases, date, promotion, sport, and country.
- Adds a per-user Comet manifest integration alongside TorBox, Usenet Ultimate, and Easynews.
- Keeps SSS as the installed catalog/metadata addon while forwarding event stream requests to the user's compatible Comet instance.
- Encrypts Comet manifest URLs at rest and requires an operator `COMET_ALLOWED_HOSTS` exact host/port allowlist.
- Adds an account setup guide, enable switch, connection test, and per-promotion Comet pipeline toggle.
- Publishes the matching SSS and AIOStreams POC images.

## Why

SSS event IDs are not generic movie or television IDs. Hosted aggregators need safe, user-scoped event context to search sports releases by title. Returning Comet streams through SSS preserves the complete sports catalog in Nuvio/Stremio and removes the user's need to self-host scraper services.

The user configures Comet with their private SSS manifest and debrid account, then saves the generated Comet manifest in SSS. Only SSS needs to be installed in the client.

## Validation

- JavaScript syntax checks.
- Comet manifest parsing, allowlist, capability, event URL, and stream-forwarding contract tests.
- SSS search-context route tests.
- Usenet Ultimate direct-search contract tests.
- SSS → Comet → TorBox live discovery and playback previously validated through an HTTP 302 to a signed TorBox CDN stream.
- POC container build validates these contracts before publishing.
